### PR TITLE
Handle the transparent background painting for OSR mode

### DIFF
--- a/example/QCefViewTest/MainWindow.cpp
+++ b/example/QCefViewTest/MainWindow.cpp
@@ -56,13 +56,14 @@ MainWindow::createCefView()
   QCefSetting setting;
   setting.setPlugins(false);
   setting.setWindowlessFrameRate(60);
-  setting.setBackgroundColor(QColor::fromRgba(qRgba(250, 249, 222, 255)));
+  setting.setBackgroundColor(QColor::fromRgba(qRgba(0, 255, 0, 255)));
 
   // create the QCefView widget and add it to the layout container
   // cefViewWidget = new CefViewWidget(INDEX_URL, &setting);
   cefViewWidget = new CefViewWidget("https://www.testufo.com", &setting, this);
   // cefViewWidget = new CefViewWidget("https://devicetests.com", &setting);
   ui.cefContainer->layout()->addWidget(cefViewWidget);
+  cefViewWidget->setStyleSheet("background-color: blue;");
 
   // connect the invokeMethod to the slot
   connect(cefViewWidget, &QCefView::invokeMethod, this, &MainWindow::onInvokeMethod);

--- a/example/QCefViewTest/main.cpp
+++ b/example/QCefViewTest/main.cpp
@@ -15,6 +15,7 @@ main(int argc, char* argv[])
   config.setLogLevel(QCefConfig::LOGSEVERITY_DEFAULT);
   config.setBridgeObjectName("CallBridge");
   config.setRemoteDebuggingPort(9000);
+  config.setBackgroundColor(QColor::fromRgba(qRgba(255, 0, 0, 255)));
 
   // add command line args
   // config.addCommandLineSwitch("allow-universal-access-from-files");

--- a/include/QCefConfig.h
+++ b/include/QCefConfig.h
@@ -188,7 +188,7 @@ public:
   /// into all browser and frames. This object is designated for communicating
   /// between Javascript in web content and native context(C/C++) code.
   /// This object is set as an property of window object. That means it can be
-  /// obtained by calling window.bridgeObject in the Javascript code.
+  /// obtained by calling window.bridgeObject in the Javascript code
   /// </remarks>
   void setBridgeObjectName(const QString& name);
 
@@ -201,6 +201,11 @@ public:
   /// Sets the background color of the web page
   /// </summary>
   /// <param name="color">The color to be set</param>
+  /// <remarks>
+  /// This only works if the web page has no background color set. The alpha component value
+  /// will be adjusted to 0 or 255, it means if you pass a value with alpha value
+  /// in the range of [1, 255], it will be accepted as 255. The default value is qRgba(255, 255,. 255, 255)
+  /// </remarks>
   void setBackgroundColor(const QColor& color);
 
   /// <summary>

--- a/include/QCefContext.h
+++ b/include/QCefContext.h
@@ -71,6 +71,12 @@ public:
   /// <returns>True on success; otherwise false</returns>
   bool addCookie(const QString& name, const QString& value, const QString& domain, const QString& url);
 
+  /// <summary>
+  /// Gets the QCefConfig
+  /// </summary>
+  /// <returns>The QCefConfig instance</returns>
+  const QCefConfig* cefConfig() const;
+
 protected:
   /// <summary>
   /// Initialize the CEF context

--- a/include/QCefSetting.h
+++ b/include/QCefSetting.h
@@ -360,6 +360,12 @@ public:
   /// Sets the background color
   /// </summary>
   /// <param name="value">The color</param>
+  /// <remarks>
+  /// This only works if the web page has no background color set. The alpha component value
+  /// will be adjusted to 0 or 255, it means if you pass a value with alpha value
+  /// in the range of [1, 255], it will be accepted as 255. The default value is inherited from
+  /// <see cref="QCefConfig::backgroundColor()"/>
+  /// </remarks>
   void setBackgroundColor(const QColor& value);
 
   /// <summary>

--- a/src/QCefContext.cpp
+++ b/src/QCefContext.cpp
@@ -53,6 +53,13 @@ QCefContext::addCookie(const QString& name, const QString& value, const QString&
   return d->addGlobalCookie(name.toStdString(), value.toStdString(), domain.toStdString(), url.toStdString());
 }
 
+const QCefConfig*
+QCefContext::cefConfig() const
+{
+  Q_D(const QCefContext);
+  return d->cefConfig();
+}
+
 bool
 QCefContext::init(const QCefConfig* config)
 {

--- a/src/QCefView.cpp
+++ b/src/QCefView.cpp
@@ -4,6 +4,7 @@
 #include <QPainter>
 #include <QPoint>
 #include <QResizeEvent>
+#include <QStyleOption>
 #include <QVBoxLayout>
 #include <QtDebug>
 #pragma endregion qt_headers
@@ -206,11 +207,18 @@ QCefView::paintEvent(QPaintEvent* event)
   Q_D(QCefView);
 
 #if defined(CEF_USE_OSR)
+  // 1. constructs painter for current widget
   QPainter painter(this);
 
-  // paint background
+  // 2. paint background with background role
   painter.fillRect(rect(), palette().color(backgroundRole()));
 
+  // 3. paint widget with its stylesheet
+  QStyleOption opt;
+  opt.initFrom(this);
+  style()->drawPrimitive(QStyle::PE_Widget, &opt, &painter, this);
+
+  // 4. paint the CEF view and pop-up
   // get current scale factor
   qreal scaleFactor = devicePixelRatio();
 
@@ -231,6 +239,7 @@ QCefView::paintEvent(QPaintEvent* event)
   }
 #endif
 
+  // 5. call base paintEvent (empty implementation)
   QWidget::paintEvent(event);
 }
 

--- a/src/details/QCefConfigPrivate.cpp
+++ b/src/details/QCefConfigPrivate.cpp
@@ -10,6 +10,7 @@
 
 QCefConfigPrivate::QCefConfigPrivate()
 {
+  backgroundColor_ = QColor::fromRgba(qRgba(255, 255, 255, 255));
   userAgent_ = kCefViewDefaultUserAgent;
 
 #if !defined(Q_OS_MACOS)
@@ -39,6 +40,10 @@ QCefConfigPrivate::CopyToCefSettings(const QCefConfig* config, CefSettings* sett
   if (!config) {
     // just copy the mandatory fields
     QCefConfigPrivate cfg;
+
+    settings->background_color = config->d_ptr->backgroundColor_.value<QColor>().rgba();
+    CefString(&settings->user_agent) = config->d_ptr->userAgent_;
+
 #if !defined(Q_OS_MACOS)
     CefString(&settings->browser_subprocess_path) = cfg.browserSubProcessPath_;
     CefString(&settings->resources_dir_path) = cfg.resourceDirectoryPath_;

--- a/src/details/QCefContextPrivate.cpp
+++ b/src/details/QCefContextPrivate.cpp
@@ -37,11 +37,18 @@ QCefContextPrivate::getCefApp()
 bool
 QCefContextPrivate::initialize(const QCefConfig* config)
 {
+  config_ = config;
   if (!initializeCef(config)) {
     return false;
   }
 
   return true;
+}
+
+const QCefConfig*
+QCefContextPrivate::cefConfig() const
+{
+  return config_;
 }
 
 void
@@ -118,9 +125,11 @@ QCefContextPrivate::onAboutToQuit()
   }
 }
 
+#if defined(Q_OS_MACOS)
 void
 QCefContextPrivate::performCefLoopWork()
 {
   // process cef work
   CefDoMessageLoopWork();
 }
+#endif

--- a/src/details/QCefContextPrivate.h
+++ b/src/details/QCefContextPrivate.h
@@ -47,9 +47,13 @@ private:
   char** argv_;
 
 private:
-  QTimer cefWorkerTimer_;
+  const QCefConfig* config_;
   QList<FolderResourceMapping> folderResourceMappingList_;
   QList<ArchiveResourceMapping> archiveResourceMappingList_;
+
+#if defined(Q_OS_MACOS)
+  QTimer cefWorkerTimer_;
+#endif
 
 private:
   CefRefPtr<CefViewBrowserApp> pApp_;
@@ -78,6 +82,12 @@ public:
   /// <param name="config"></param>
   /// <returns></returns>
   bool initialize(const QCefConfig* config);
+
+  /// <summary>
+  ///
+  /// </summary>
+  /// <returns></returns>
+  const QCefConfig* cefConfig() const;
 
   /// <summary>
   /// Adds a url mapping item with local web resource directory
@@ -136,10 +146,12 @@ public slots:
   /// </summary>
   void onAboutToQuit();
 
+#if defined(Q_OS_MACOS)
   /// <summary>
   ///
   /// </summary>
   void performCefLoopWork();
+#endif
 
 protected:
   /// <summary>

--- a/src/details/QCefSettingPrivate.cpp
+++ b/src/details/QCefSettingPrivate.cpp
@@ -7,9 +7,15 @@
 #include <QString>
 #pragma endregion qt_headers
 
+#include <QCefContext.h>
+
 #include <CefViewCoreProtocol.h>
 
-QCefSettingPrivate::QCefSettingPrivate() {}
+QCefSettingPrivate::QCefSettingPrivate()
+{
+  auto cefConfig = QCefContext::instance()->cefConfig();
+  backgroundColor_ = cefConfig->backgroundColor();
+}
 
 void
 QCefSettingPrivate::CopyFromCefBrowserSettings(QCefSetting* qs, const CefBrowserSettings* cs)
@@ -88,8 +94,13 @@ QCefSettingPrivate::CopyFromCefBrowserSettings(QCefSetting* qs, const CefBrowser
 void
 QCefSettingPrivate::CopyToCefBrowserSettings(const QCefSetting* qs, CefBrowserSettings* cs)
 {
-  if (!qs || !cs)
+  if (!cs)
     return;
+
+  if (!qs) {
+    QCefSettingPrivate defaultSettings;
+    cs->background_color = qs->d_ptr->backgroundColor_.value<QColor>().rgba();
+  }
 
   if (!qs->d_ptr->standardFontFamily_.empty())
     CefString(&cs->standard_font_family) = qs->d_ptr->standardFontFamily_;

--- a/src/details/QCefViewPrivate.h
+++ b/src/details/QCefViewPrivate.h
@@ -64,6 +64,11 @@ public:
     /// <summary>
     ///
     /// </summary>
+    bool transparentPaintingEnabled = false;
+
+    /// <summary>
+    ///
+    /// </summary>
     bool showPopup_ = false;
 
     /// <summary>


### PR DESCRIPTION
When the background is tranparent, replace the full cache image instead of updating dirty region