### PR TITLE
Feature/context menu

### DIFF
--- a/example/QCefViewTest/MainWindow.cpp
+++ b/example/QCefViewTest/MainWindow.cpp
@@ -1,4 +1,4 @@
-#include "MainWindow.h"
+﻿#include "MainWindow.h"
 
 #include <QCoreApplication>
 #include <QDir>
@@ -66,6 +66,9 @@ MainWindow::createCefView()
   // this site is for test web events
   cefViewWidget = new CefViewWidget("http://output.jsbin.com/rinece", &setting, this);
 
+  //
+  // cefViewWidget = new CefViewWidget("https://mdn.dev/", &setting, this);
+
   // this site is for test OSR performance
   // cefViewWidget = new CefViewWidget("https://www.testufo.com", &setting, this);
 
@@ -73,7 +76,8 @@ MainWindow::createCefView()
   // cefViewWidget = new CefViewWidget("https://devicetests.com", &setting);
 
   ui.cefContainer->layout()->addWidget(cefViewWidget);
-  cefViewWidget->setStyleSheet("background-color: blue;");
+
+  // cefViewWidget->setCefContextMenuPolicy(Qt::CefDisableAllContextMenu);
 
   // connect the invokeMethod to the slot
   connect(cefViewWidget, &QCefView::invokeMethod, this, &MainWindow::onInvokeMethod);

--- a/include/QCefView.h
+++ b/include/QCefView.h
@@ -1,4 +1,4 @@
-﻿#ifndef QCEFVIEW_H
+#ifndef QCEFVIEW_H
 #define QCEFVIEW_H
 #pragma once
 #include <QCefView_global.h>
@@ -16,6 +16,39 @@
 
 class QCefViewPrivate;
 
+namespace Qt {
+Q_NAMESPACE
+/// <summary>
+/// Represents the CEF popup windows open disposition
+/// </summary>
+enum CefWindowOpenDisposition
+{
+  CefWindowOpenDispositionUnknown,
+  CefWindowOpenDispositionCurrentTab,
+  CefWindowOpenDispositionSingletonTab,
+  CefWindowOpenDispositionNewForeGroundTab,
+  CefWindowOpenDispositionNewBackgroundTab,
+  CefWindowOpenDispositionNewPopup,
+  CefWindowOpenDispositionNewWindow,
+  CefWindowOpenDispositionSaveToDisk,
+  CefWindowOpenDispositionOffTheRecord,
+  CefWindowOpenDispositionIgnoreAction,
+};
+Q_ENUM_NS(CefWindowOpenDisposition)
+
+/// <summary>
+/// Represents the CEF context menu policy
+/// </summary>
+enum CefContextMenuPolicy
+{
+  CefAllowContextMenu = 0x0000,
+  CefDisableMainContextMenu = 0x0001,
+  CefDisablePopupContextMenu = 0x0002,
+  CefDisableAllContextMenu = (CefDisableMainContextMenu | CefDisablePopupContextMenu),
+};
+Q_FLAG_NS(CefContextMenuPolicy)
+} // namespace Qt
+
 /// <summary>
 /// Represents the CEF browser view
 /// </summary>
@@ -28,25 +61,6 @@ class QCEFVIEW_EXPORT QCefView : public QWidget
 
 public:
   static const qint64 MainFrameID = 0;
-
-public:
-  /// <summary>
-  ///
-  /// </summary>
-  enum WindowOpenDisposition
-  {
-    WOD_UNKNOWN,
-    WOD_CURRENT_TAB,
-    WOD_SINGLETON_TAB,
-    WOD_NEW_FOREGROUND_TAB,
-    WOD_NEW_BACKGROUND_TAB,
-    WOD_NEW_POPUP,
-    WOD_NEW_WINDOW,
-    WOD_SAVE_TO_DISK,
-    WOD_OFF_THE_RECORD,
-    WOD_IGNORE_ACTION
-  };
-  Q_ENUM(WindowOpenDisposition)
 
 public:
   /// <summary>
@@ -205,9 +219,21 @@ public:
   /// The preference value, if this value is QVariant::UnknownType or QVariant::Invalid, the
   /// preference will be restored to default value
   /// </param>
-  /// <param name="error">The error message populated on failure</param> <returns>True
-  /// on successful; otherwise false</returns>
+  /// <param name="error">The error message populated on failure</param>
+  // <returns>True on successful; otherwise false</returns>
   bool setPreference(const QString& name, const QVariant& value, const QString& error);
+
+  /// <summary>
+  /// Sets the cef context menu policy
+  /// </summary>
+  /// <param name="policy">The policy</param>
+  void setCefContextMenuPolicy(Qt::CefContextMenuPolicy policy);
+
+  /// <summary>
+  /// Gets the cef context menu policy
+  /// </summary>
+  // <returns>The cef context menu policy</returns>
+  Qt::CefContextMenuPolicy cefContextMenuPolicy();
 
 signals:
   /// <summary>
@@ -356,7 +382,7 @@ public slots:
   virtual bool onBeforePopup(qint64 frameId,
                              const QString& targetUrl,
                              const QString& targetFrameName,
-                             QCefView::WindowOpenDisposition targetDisposition,
+                             Qt::CefWindowOpenDisposition targetDisposition,
                              QCefSetting& settings,
                              bool& DisableJavascriptAccess);
 
@@ -371,7 +397,10 @@ public slots:
   /// <summary>
   ///
   /// </summary>
-  inline void setFocus() { setFocus(Qt::OtherFocusReason); }
+  inline void setFocus()
+  {
+    setFocus(Qt::OtherFocusReason);
+  }
 
 public:
   /// <summary>

--- a/include/QCefView.h
+++ b/include/QCefView.h
@@ -1,4 +1,4 @@
-#ifndef QCEFVIEW_H
+﻿#ifndef QCEFVIEW_H
 #define QCEFVIEW_H
 #pragma once
 #include <QCefView_global.h>
@@ -16,39 +16,6 @@
 
 class QCefViewPrivate;
 
-namespace Qt {
-Q_NAMESPACE
-/// <summary>
-/// Represents the CEF popup windows open disposition
-/// </summary>
-enum CefWindowOpenDisposition
-{
-  CefWindowOpenDispositionUnknown,
-  CefWindowOpenDispositionCurrentTab,
-  CefWindowOpenDispositionSingletonTab,
-  CefWindowOpenDispositionNewForeGroundTab,
-  CefWindowOpenDispositionNewBackgroundTab,
-  CefWindowOpenDispositionNewPopup,
-  CefWindowOpenDispositionNewWindow,
-  CefWindowOpenDispositionSaveToDisk,
-  CefWindowOpenDispositionOffTheRecord,
-  CefWindowOpenDispositionIgnoreAction,
-};
-Q_ENUM_NS(CefWindowOpenDisposition)
-
-/// <summary>
-/// Represents the CEF context menu policy
-/// </summary>
-enum CefContextMenuPolicy
-{
-  CefAllowContextMenu = 0x0000,
-  CefDisableMainContextMenu = 0x0001,
-  CefDisablePopupContextMenu = 0x0002,
-  CefDisableAllContextMenu = (CefDisableMainContextMenu | CefDisablePopupContextMenu),
-};
-Q_FLAG_NS(CefContextMenuPolicy)
-} // namespace Qt
-
 /// <summary>
 /// Represents the CEF browser view
 /// </summary>
@@ -60,7 +27,28 @@ class QCEFVIEW_EXPORT QCefView : public QWidget
   QScopedPointer<QCefViewPrivate> d_ptr;
 
 public:
+  /// <summary>
+  /// The main frame identity
+  /// </summary>
   static const qint64 MainFrameID = 0;
+
+  /// <summary>
+  /// Represents the CEF popup windows open disposition
+  /// </summary>
+  enum CefWindowOpenDisposition
+  {
+    CefWindowOpenDispositionUnknown,
+    CefWindowOpenDispositionCurrentTab,
+    CefWindowOpenDispositionSingletonTab,
+    CefWindowOpenDispositionNewForeGroundTab,
+    CefWindowOpenDispositionNewBackgroundTab,
+    CefWindowOpenDispositionNewPopup,
+    CefWindowOpenDispositionNewWindow,
+    CefWindowOpenDispositionSaveToDisk,
+    CefWindowOpenDispositionOffTheRecord,
+    CefWindowOpenDispositionIgnoreAction,
+  };
+  Q_ENUM(CefWindowOpenDisposition)
 
 public:
   /// <summary>
@@ -224,16 +212,16 @@ public:
   bool setPreference(const QString& name, const QVariant& value, const QString& error);
 
   /// <summary>
-  /// Sets the cef context menu policy
+  /// Sets whether to disable the context menu for popup browser
   /// </summary>
-  /// <param name="policy">The policy</param>
-  void setCefContextMenuPolicy(Qt::CefContextMenuPolicy policy);
+  /// <param name="disable">True to disable; otherwise false</param>
+  void setDisablePopupContextMenu(bool disable);
 
   /// <summary>
-  /// Gets the cef context menu policy
+  /// Gets whether to disable the context menu for popup browser
   /// </summary>
-  // <returns>The cef context menu policy</returns>
-  Qt::CefContextMenuPolicy cefContextMenuPolicy();
+  /// <returns>True to disable; otherwise false</returns>
+  bool isPopupContextMenuDisabled();
 
 signals:
   /// <summary>
@@ -370,7 +358,7 @@ public slots:
   virtual void onBrowserWindowCreated(QWindow* win);
 
   /// <summary>
-  /// Gets called before the pop-up browser created
+  /// Gets called before the popup browser created
   /// </summary>
   /// <param name="frameId">The source frame id</param>
   /// <param name="targetUrl">The target URL</param>
@@ -382,12 +370,12 @@ public slots:
   virtual bool onBeforePopup(qint64 frameId,
                              const QString& targetUrl,
                              const QString& targetFrameName,
-                             Qt::CefWindowOpenDisposition targetDisposition,
+                             QCefView::CefWindowOpenDisposition targetDisposition,
                              QCefSetting& settings,
                              bool& DisableJavascriptAccess);
 
   /// <summary>
-  /// Gets called right after the pop-up browser was created
+  /// Gets called right after the popup browser was created
   /// </summary>
   /// <param name="wnd">The host window of new created browser</param>
   virtual void onPopupCreated(QWindow* wnd);
@@ -397,10 +385,7 @@ public slots:
   /// <summary>
   ///
   /// </summary>
-  inline void setFocus()
-  {
-    setFocus(Qt::OtherFocusReason);
-  }
+  inline void setFocus() { setFocus(Qt::OtherFocusReason); }
 
 public:
   /// <summary>
@@ -478,6 +463,8 @@ protected:
   /// Please refer to QWidget::wheelEvent
   /// </summary>
   void wheelEvent(QWheelEvent* event) override;
+
+  void contextMenuEvent(QContextMenuEvent* event) override;
 #pragma endregion
 };
 

--- a/src/QCefView.cpp
+++ b/src/QCefView.cpp
@@ -1,4 +1,4 @@
-#include <QCefView.h>
+﻿#include <QCefView.h>
 
 #pragma region qt_headers
 #include <QPainter>
@@ -13,6 +13,7 @@
 
 #include "details/QCefEventPrivate.h"
 #include "details/QCefViewPrivate.h"
+#include "details/utils/CommonUtils.h"
 
 QCefView::QCefView(const QString url, const QCefSetting* setting, QWidget* parent /*= 0*/)
   : QWidget(parent)
@@ -29,8 +30,7 @@ QCefView::QCefView(const QString url, const QCefSetting* setting, QWidget* paren
 
 QCefView::QCefView(QWidget* parent /*= 0*/)
   : QCefView("about:blank", nullptr, parent)
-{
-}
+{}
 
 QCefView::~QCefView()
 {
@@ -193,19 +193,19 @@ QCefView::setPreference(const QString& name, const QVariant& value, const QStrin
 }
 
 void
-QCefView::setCefContextMenuPolicy(Qt::CefContextMenuPolicy policy)
+QCefView::setDisablePopupContextMenu(bool disable)
 {
   Q_D(QCefView);
 
-  d->cefContextMenuPolicy_ = policy;
+  d->disablePopuContextMenu_ = disable;
 }
 
-Qt::CefContextMenuPolicy
-QCefView::cefContextMenuPolicy()
+bool
+QCefView::isPopupContextMenuDisabled()
 {
   Q_D(QCefView);
 
-  return d->cefContextMenuPolicy_;
+  return d->disablePopuContextMenu_;
 }
 
 void
@@ -218,14 +218,13 @@ QCefView::setFocus(Qt::FocusReason reason)
 
 void
 QCefView::onBrowserWindowCreated(QWindow* win)
-{
-}
+{}
 
 bool
 QCefView::onBeforePopup(qint64 frameId,
                         const QString& targetUrl,
                         const QString& targetFrameName,
-                        Qt::CefWindowOpenDisposition targetDisposition,
+                        QCefView::CefWindowOpenDisposition targetDisposition,
                         QCefSetting& settings,
                         bool& DisableJavascriptAccess)
 {
@@ -235,8 +234,7 @@ QCefView::onBeforePopup(qint64 frameId,
 
 void
 QCefView::onPopupCreated(QWindow* wnd)
-{
-}
+{}
 
 QVariant
 QCefView::inputMethodQuery(Qt::InputMethodQuery query) const
@@ -268,7 +266,7 @@ QCefView::paintEvent(QPaintEvent* event)
   opt.initFrom(this);
   style()->drawPrimitive(QStyle::PE_Widget, &opt, &painter, this);
 
-  // 4. paint the CEF view and pop-up
+  // 4. paint the CEF view and popup
   // get current scale factor
   qreal scaleFactor = devicePixelRatio();
 
@@ -281,7 +279,7 @@ QCefView::paintEvent(QPaintEvent* event)
     painter.drawImage(QRect{ 0, 0, width, height }, d->osr.qCefViewFrame_);
   }
   {
-    // paint cef pop-up
+    // paint cef popup
     QMutexLocker lock(&(d->osr.qPopupPaintLock_));
     if (d->osr.showPopup_) {
       painter.drawImage(d->osr.qPopupRect_, d->osr.qCefPopupFrame_);
@@ -386,4 +384,18 @@ QCefView::wheelEvent(QWheelEvent* event)
   Q_D(QCefView);
   d->onViewWheelEvent(event);
   QWidget::wheelEvent(event);
+}
+
+void
+QCefView::contextMenuEvent(QContextMenuEvent* event)
+{
+  FLog();
+
+#if defined(CEF_USE_OSR)
+  Q_D(QCefView);
+
+  if (d->osr.isShowingContextMenu_) {
+    d->osr.contextMenu_->popup(mapToGlobal(event->pos()));
+  }
+#endif
 }

--- a/src/QCefView.cpp
+++ b/src/QCefView.cpp
@@ -1,4 +1,4 @@
-﻿#include <QCefView.h>
+#include <QCefView.h>
 
 #pragma region qt_headers
 #include <QPainter>
@@ -29,7 +29,8 @@ QCefView::QCefView(const QString url, const QCefSetting* setting, QWidget* paren
 
 QCefView::QCefView(QWidget* parent /*= 0*/)
   : QCefView("about:blank", nullptr, parent)
-{}
+{
+}
 
 QCefView::~QCefView()
 {
@@ -192,6 +193,22 @@ QCefView::setPreference(const QString& name, const QVariant& value, const QStrin
 }
 
 void
+QCefView::setCefContextMenuPolicy(Qt::CefContextMenuPolicy policy)
+{
+  Q_D(QCefView);
+
+  d->cefContextMenuPolicy_ = policy;
+}
+
+Qt::CefContextMenuPolicy
+QCefView::cefContextMenuPolicy()
+{
+  Q_D(QCefView);
+
+  return d->cefContextMenuPolicy_;
+}
+
+void
 QCefView::setFocus(Qt::FocusReason reason)
 {
   Q_D(QCefView);
@@ -201,13 +218,14 @@ QCefView::setFocus(Qt::FocusReason reason)
 
 void
 QCefView::onBrowserWindowCreated(QWindow* win)
-{}
+{
+}
 
 bool
 QCefView::onBeforePopup(qint64 frameId,
                         const QString& targetUrl,
                         const QString& targetFrameName,
-                        QCefView::WindowOpenDisposition targetDisposition,
+                        Qt::CefWindowOpenDisposition targetDisposition,
                         QCefSetting& settings,
                         bool& DisableJavascriptAccess)
 {
@@ -217,7 +235,8 @@ QCefView::onBeforePopup(qint64 frameId,
 
 void
 QCefView::onPopupCreated(QWindow* wnd)
-{}
+{
+}
 
 QVariant
 QCefView::inputMethodQuery(Qt::InputMethodQuery query) const

--- a/src/details/CCefClientDelegate_ContextMenuHandler.cpp
+++ b/src/details/CCefClientDelegate_ContextMenuHandler.cpp
@@ -1,4 +1,6 @@
-﻿#include "CCefClientDelegate.h"
+#include "CCefClientDelegate.h"
+
+#include <QDebug>
 
 #include "QCefViewPrivate.h"
 
@@ -8,11 +10,27 @@ CCefClientDelegate::onBeforeContextMenu(CefRefPtr<CefBrowser> browser,
                                         CefRefPtr<CefContextMenuParams> params,
                                         CefRefPtr<CefMenuModel> model)
 {
+  if (!pCefViewPrivate_)
+    return;
+  
+  qDebug() << "onBeforeContextMenu, menu item count:" << model->GetCount();
+  
+  if (browser->IsPopup()) {
+    // pop-up browser doesn't involve off-screen renderring
+    if (Qt::CefDisablePopupContextMenu & pCefViewPrivate_->cefContextMenuPolicy_) {
+      model->Clear();
+    }
+  } else {
+    // main browser
+    if (Qt::CefDisableMainContextMenu & pCefViewPrivate_->cefContextMenuPolicy_) {
+      model->Clear();
+    }
+  }
+  
 #if defined(CEF_USE_OSR)
   // Context menu will not disappear on left click under OSR
   // mode, so we just disable the default one. You need to
   // implement your own context menu.
-  model->Clear();
 #endif
 }
 
@@ -38,4 +56,6 @@ CCefClientDelegate::onContextMenuCommand(CefRefPtr<CefBrowser> browser,
 
 void
 CCefClientDelegate::onContextMenuDismissed(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame)
-{}
+{
+  qDebug() << "onContextMenuDismissed";
+}

--- a/src/details/CCefClientDelegate_ContextMenuHandler.cpp
+++ b/src/details/CCefClientDelegate_ContextMenuHandler.cpp
@@ -1,6 +1,10 @@
-#include "CCefClientDelegate.h"
+﻿#include "CCefClientDelegate.h"
 
 #include <QDebug>
+#include <QThread>
+
+#include "utils/CommonUtils.h"
+#include "utils/MenuBuilder.h"
 
 #include "QCefViewPrivate.h"
 
@@ -10,28 +14,31 @@ CCefClientDelegate::onBeforeContextMenu(CefRefPtr<CefBrowser> browser,
                                         CefRefPtr<CefContextMenuParams> params,
                                         CefRefPtr<CefMenuModel> model)
 {
+  FLog();
+
   if (!pCefViewPrivate_)
     return;
-  
-  qDebug() << "onBeforeContextMenu, menu item count:" << model->GetCount();
-  
+
+  // popup browser doesn't involve off-screen rendering
   if (browser->IsPopup()) {
-    // pop-up browser doesn't involve off-screen renderring
-    if (Qt::CefDisablePopupContextMenu & pCefViewPrivate_->cefContextMenuPolicy_) {
+    if (pCefViewPrivate_->disablePopuContextMenu_) {
       model->Clear();
     }
-  } else {
-    // main browser
-    if (Qt::CefDisableMainContextMenu & pCefViewPrivate_->cefContextMenuPolicy_) {
-      model->Clear();
-    }
+
+    return;
   }
-  
-#if defined(CEF_USE_OSR)
-  // Context menu will not disappear on left click under OSR
-  // mode, so we just disable the default one. You need to
-  // implement your own context menu.
-#endif
+
+  // main browser
+  auto policy = pCefViewPrivate_->q_ptr->contextMenuPolicy();
+  if (Qt::DefaultContextMenu != policy) {
+    model->Clear();
+    return;
+  }
+
+  auto menuData = MenuBuilder::CreateMenuDataFromCefMenu(model.get());
+  QMetaObject::invokeMethod(pCefViewPrivate_, [=]() { pCefViewPrivate_->onBeforeCefContextMenu(menuData); });
+
+  return;
 }
 
 bool
@@ -41,7 +48,21 @@ CCefClientDelegate::onRunContextMenu(CefRefPtr<CefBrowser> browser,
                                      CefRefPtr<CefMenuModel> model,
                                      CefRefPtr<CefRunContextMenuCallback> callback)
 {
-  return false;
+  FLog();
+
+  if (browser->IsPopup()) {
+    return false;
+  }
+
+  auto policy = pCefViewPrivate_->q_ptr->contextMenuPolicy();
+  if (Qt::DefaultContextMenu != policy) {
+    return false;
+  }
+
+  QPoint pos(params->GetXCoord(), params->GetYCoord());
+  QMetaObject::invokeMethod(pCefViewPrivate_, [=]() { pCefViewPrivate_->onRunCefContextMenu(pos, callback); });
+
+  return true;
 }
 
 bool
@@ -51,11 +72,15 @@ CCefClientDelegate::onContextMenuCommand(CefRefPtr<CefBrowser> browser,
                                          int command_id,
                                          CefContextMenuHandler::EventFlags event_flags)
 {
+  FLog();
+
   return false;
 }
 
 void
 CCefClientDelegate::onContextMenuDismissed(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame)
 {
-  qDebug() << "onContextMenuDismissed";
+  FLog();
+
+  QMetaObject::invokeMethod(pCefViewPrivate_, [=]() { pCefViewPrivate_->onCefContextMenuDismissed(); });
 }

--- a/src/details/CCefClientDelegate_KeyboardHandler.cpp
+++ b/src/details/CCefClientDelegate_KeyboardHandler.cpp
@@ -1,8 +1,6 @@
 #include "CCefClientDelegate.h"
 
 #include <QDebug>
-#include <QImage>
-#include <QScreen>
 
 #include "QCefViewPrivate.h"
 

--- a/src/details/CCefClientDelegate_LifeSpanHandler.cpp
+++ b/src/details/CCefClientDelegate_LifeSpanHandler.cpp
@@ -1,4 +1,4 @@
-#include "CCefClientDelegate.h"
+﻿#include "CCefClientDelegate.h"
 
 #include <QThread>
 
@@ -21,21 +21,21 @@ CCefClientDelegate::onBeforePopup(CefRefPtr<CefBrowser>& browser,
     auto name = QString::fromStdString(targetFrameName);
 
     QCefSetting s;
-    Qt::CefWindowOpenDisposition d = (Qt::CefWindowOpenDisposition)targetDisposition;
+    QCefView::CefWindowOpenDisposition d = (QCefView::CefWindowOpenDisposition)targetDisposition;
     QCefSettingPrivate::CopyFromCefBrowserSettings(&s, &settings);
 
     Qt::ConnectionType c = pCefViewPrivate_->q_ptr->thread() == QThread::currentThread() ? Qt::DirectConnection
                                                                                          : Qt::BlockingQueuedConnection;
     QMetaObject::invokeMethod(pCefViewPrivate_->q_ptr,
-                              "onBeforePopup",                        //
-                              c,                                      //
-                              Q_RETURN_ARG(bool, result),             //
-                              Q_ARG(qint64, frameId),                 //
-                              Q_ARG(const QString&, url),             //
-                              Q_ARG(const QString&, name),            //
-                              Q_ARG(Qt::CefWindowOpenDisposition, d), //
-                              Q_ARG(QCefSetting&, s),                 //
-                              Q_ARG(bool&, DisableJavascriptAccess)   //
+                              "onBeforePopup",                              //
+                              c,                                            //
+                              Q_RETURN_ARG(bool, result),                   //
+                              Q_ARG(qint64, frameId),                       //
+                              Q_ARG(const QString&, url),                   //
+                              Q_ARG(const QString&, name),                  //
+                              Q_ARG(QCefView::CefWindowOpenDisposition, d), //
+                              Q_ARG(QCefSetting&, s),                       //
+                              Q_ARG(bool&, DisableJavascriptAccess)         //
     );
     QCefSettingPrivate::CopyToCefBrowserSettings(&s, &settings);
   }

--- a/src/details/CCefClientDelegate_LifeSpanHandler.cpp
+++ b/src/details/CCefClientDelegate_LifeSpanHandler.cpp
@@ -1,4 +1,4 @@
-﻿#include "CCefClientDelegate.h"
+#include "CCefClientDelegate.h"
 
 #include <QThread>
 
@@ -21,21 +21,21 @@ CCefClientDelegate::onBeforePopup(CefRefPtr<CefBrowser>& browser,
     auto name = QString::fromStdString(targetFrameName);
 
     QCefSetting s;
-    QCefView::WindowOpenDisposition d = (QCefView::WindowOpenDisposition)targetDisposition;
+    Qt::CefWindowOpenDisposition d = (Qt::CefWindowOpenDisposition)targetDisposition;
     QCefSettingPrivate::CopyFromCefBrowserSettings(&s, &settings);
 
     Qt::ConnectionType c = pCefViewPrivate_->q_ptr->thread() == QThread::currentThread() ? Qt::DirectConnection
                                                                                          : Qt::BlockingQueuedConnection;
     QMetaObject::invokeMethod(pCefViewPrivate_->q_ptr,
-                              "onBeforePopup",                           //
-                              c,                                         //
-                              Q_RETURN_ARG(bool, result),                //
-                              Q_ARG(qint64, frameId),                    //
-                              Q_ARG(const QString&, url),                //
-                              Q_ARG(const QString&, name),               //
-                              Q_ARG(QCefView::WindowOpenDisposition, d), //
-                              Q_ARG(QCefSetting&, s),                    //
-                              Q_ARG(bool&, DisableJavascriptAccess)      //
+                              "onBeforePopup",                        //
+                              c,                                      //
+                              Q_RETURN_ARG(bool, result),             //
+                              Q_ARG(qint64, frameId),                 //
+                              Q_ARG(const QString&, url),             //
+                              Q_ARG(const QString&, name),            //
+                              Q_ARG(Qt::CefWindowOpenDisposition, d), //
+                              Q_ARG(QCefSetting&, s),                 //
+                              Q_ARG(bool&, DisableJavascriptAccess)   //
     );
     QCefSettingPrivate::CopyToCefBrowserSettings(&s, &settings);
   }

--- a/src/details/QCefViewPrivate.h
+++ b/src/details/QCefViewPrivate.h
@@ -1,6 +1,8 @@
-#pragma once
+﻿#pragma once
 #pragma region qt_headers
+#include <QMenu>
 #include <QMutex>
+#include <QPointer>
 #include <QSet>
 #include <QString>
 #include <QWindow>
@@ -15,6 +17,7 @@
 
 #include "CCefClientDelegate.h"
 #include "QCefContextPrivate.h"
+#include "utils/MenuBuilder.h"
 
 #include <QCefView.h>
 
@@ -38,7 +41,7 @@ public:
   /// <summary>
   ///
   /// </summary>
-  Qt::CefContextMenuPolicy cefContextMenuPolicy_ = Qt::CefAllowContextMenu;
+  bool disablePopuContextMenu_ = false;
 
   /// <summary>
   ///
@@ -105,6 +108,21 @@ public:
     ///
     /// </summary>
     QImage qCefPopupFrame_;
+
+    /// <summary>
+    ///
+    /// </summary>
+    bool isShowingContextMenu_ = false;
+
+    /// <summary>
+    ///
+    /// </summary>
+    QMenu* contextMenu_ = nullptr;
+
+    /// <summary>
+    ///
+    /// </summary>
+    CefRefPtr<CefRunContextMenuCallback> contextMenuCallback_;
   } osr;
 #else
   /// <summary>
@@ -181,6 +199,10 @@ public slots:
 
   void onOsrResizePopup(const QRect& rc);
 
+  void onContextMenuTriggered(QAction* action);
+
+  void onContextMenuDestroyed(QObject* obj);
+
 signals:
   void updateOsrFrame();
 
@@ -188,6 +210,12 @@ protected:
   void onOsrUpdateViewFrame(const QImage& frame, const QRegion& region);
 
   void onOsrUpdatePopupFrame(const QImage& frame, const QRegion& region);
+
+  void onBeforeCefContextMenu(const MenuBuilder::MenuData& data);
+
+  void onRunCefContextMenu(QPoint pos, CefRefPtr<CefRunContextMenuCallback> callback);
+
+  void onCefContextMenuDismissed();
 #endif
 
 protected:

--- a/src/details/QCefViewPrivate.h
+++ b/src/details/QCefViewPrivate.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #pragma region qt_headers
 #include <QMutex>
 #include <QSet>
@@ -34,6 +34,11 @@ public:
   ///
   /// </summary>
   static void destroyAllInstance();
+
+  /// <summary>
+  ///
+  /// </summary>
+  Qt::CefContextMenuPolicy cefContextMenuPolicy_ = Qt::CefAllowContextMenu;
 
   /// <summary>
   ///

--- a/src/details/utils/CommonUtils.h
+++ b/src/details/utils/CommonUtils.h
@@ -1,4 +1,5 @@
-﻿#pragma once
+#pragma once
+#include <QDebug>
 #include <QMetaType>
 
 #define REGISTER_METATYPE(TYPE)                                                                                        \
@@ -6,3 +7,23 @@
   {                                                                                                                    \
     TYPE##_MetaTypeRegister() { qRegisterMetaType<TYPE>(); }                                                           \
   } TYPE##_MetaTypeRegister;
+
+class FunctionLogger
+{
+public:
+  FunctionLogger(const QString& fn)
+    : functionName_(fn)
+  {
+    qDebug() << "+++" << functionName_;
+  }
+
+  ~FunctionLogger() { qDebug() << "---" << functionName_; }
+
+  QString functionName_;
+};
+
+#if defined(QT_DEBUG)
+#define FLog() FunctionLogger __fl__(__FUNCTION__);
+#else
+#define FLog()
+#endif

--- a/src/details/utils/KeyboardUtils.h
+++ b/src/details/utils/KeyboardUtils.h
@@ -1,6 +1,7 @@
 ﻿#if defined(CEF_USE_OSR)
 #pragma once
 #include <QKeyEvent>
+
 #include <include/cef_app.h>
 
 void

--- a/src/details/utils/MenuBuilder.cpp
+++ b/src/details/utils/MenuBuilder.cpp
@@ -1,0 +1,133 @@
+﻿#include "MenuBuilder.h"
+
+#include <QActionGroup>
+
+namespace MenuBuilder {
+MenuData
+CreateMenuDataFromCefMenu(CefMenuModel* model)
+{
+  MenuData data;
+
+  if (!model)
+    return data;
+
+  for (int i = 0; i < model->GetCount(); i++) {
+    MenuItem item;
+    auto type = model->GetTypeAt(i);
+    item.type = (MenuItemType)(type);
+    item.label = QString::fromUtf8(model->GetLabelAt(i).ToString().c_str());
+    item.commandId = model->GetCommandIdAt(i);
+    item.enable = model->IsEnabledAt(i);
+    item.visible = model->IsVisibleAt(i);
+
+    int keyCode = 0;
+    bool shift = false;
+    bool ctrl = false;
+    bool alt = false;
+    auto hasAccelerator = model->GetAcceleratorAt(i, keyCode, shift, ctrl, alt);
+    if (hasAccelerator) {
+      int combination = keyCode;
+      if (shift)
+        combination += Qt::SHIFT;
+      if (ctrl)
+        combination += Qt::CTRL;
+      if (alt)
+        combination += Qt::ALT;
+      item.accelerator = combination;
+    }
+
+    switch (type) {
+      case MENUITEMTYPE_COMMAND: {
+      } break;
+      case MENUITEMTYPE_CHECK: {
+        item.checked = model->IsCheckedAt(i);
+        item.groupId = model->GetGroupIdAt(i);
+      } break;
+      case MENUITEMTYPE_RADIO: {
+        item.checked = model->IsCheckedAt(i);
+        item.groupId = model->GetGroupIdAt(i);
+      } break;
+      case MENUITEMTYPE_SEPARATOR: {
+      } break;
+      case MENUITEMTYPE_SUBMENU: {
+        auto cefSubMenu = model->GetSubMenuAt(i);
+        item.subMenuData = CreateMenuDataFromCefMenu(cefSubMenu.get());
+      } break;
+      default:
+        break;
+    }
+
+    data.append(item);
+  }
+
+  return data;
+}
+
+void
+BuildQtMenuFromMenuData(QMenu* menu, const MenuData& data)
+{
+  if (!menu || data.isEmpty())
+    return;
+
+  QMap<int, QActionGroup*> groupMap;
+
+  for (const auto& item : data) {
+    switch (item.type) {
+      case kMeueItemTypeCommand: {
+        auto action = new QAction(item.label);
+        action->setData(QVariant(item.commandId));
+        action->setEnabled(item.enable);
+        action->setVisible(item.visible);
+
+        if (item.accelerator)
+          action->setShortcut(QKeySequence(item.accelerator));
+
+        menu->addAction(action);
+      } break;
+      case kMeueItemTypeCheck: {
+        auto* action = new QAction(item.label);
+        action->setData(QVariant(item.commandId));
+        action->setEnabled(item.enable);
+        action->setVisible(item.visible);
+
+        action->setCheckable(true);
+        action->setChecked(item.checked);
+
+        menu->addAction(action);
+      } break;
+      case kMeueItemTypeRadio: {
+        auto* action = new QAction(item.label);
+        action->setData(QVariant(item.commandId));
+        action->setEnabled(item.enable);
+        action->setVisible(item.visible);
+
+        action->setCheckable(true);
+        action->setChecked(item.checked);
+
+        if (item.groupId >= 0) {
+          if (!groupMap.contains(item.groupId))
+            groupMap[item.groupId] = new QActionGroup(menu);
+
+          action->setActionGroup(groupMap[item.groupId]);
+        }
+
+        menu->addAction(action);
+      } break;
+      case kMeueItemTypeSeparator: {
+        menu->addSeparator();
+      } break;
+      case kMeueItemTypeSubMenu: {
+        if (!item.subMenuData.isEmpty()) {
+          auto subMenu = menu->addMenu(item.label);
+          BuildQtMenuFromMenuData(subMenu, item.subMenuData);
+
+          subMenu->setEnabled(item.enable);
+          subMenu->setVisible(item.visible);
+        }
+      } break;
+      default:
+        break;
+    }
+  }
+}
+} // namespace MenuBuilder

--- a/src/details/utils/MenuBuilder.h
+++ b/src/details/utils/MenuBuilder.h
@@ -1,0 +1,44 @@
+﻿#pragma once
+
+#include <QMenu>
+
+#include <include/cef_app.h>
+
+namespace MenuBuilder {
+/// <summary>
+///
+/// </summary>
+typedef enum MenuItemType
+{
+  kMeueItemTypeNone,
+  kMeueItemTypeCommand,
+  kMeueItemTypeCheck,
+  kMeueItemTypeRadio,
+  kMeueItemTypeSeparator,
+  kMeueItemTypeSubMenu,
+} MenuItemType;
+
+/// <summary>
+///
+/// </summary>
+typedef struct MenuItem
+{
+  MenuItemType type = kMeueItemTypeNone;
+  QString label;
+  int commandId = 0;
+  bool enable = false;
+  bool visible = false;
+  bool checked = false;
+  int groupId = -1;
+  int accelerator = -1;
+  QList<MenuItem> subMenuData;
+} MenuItem;
+
+typedef QList<MenuItem> MenuData;
+
+MenuData
+CreateMenuDataFromCefMenu(CefMenuModel* model);
+
+void
+BuildQtMenuFromMenuData(QMenu* menu, const MenuData& data);
+}; // namespace MenuBuilder


### PR DESCRIPTION
Add context menu handling for OSR mode.
For OSR mode
when use setContextMenuPolicy with Qt::DefaultContextMenuPolicy, the browser will show default native CEF context menu
for any other context menu policy value, the default native CEF context menu will not show