### PR TITLE
Fix NPE in CopyToCefBrowserSettings

### DIFF
--- a/src/details/QCefSettingPrivate.cpp
+++ b/src/details/QCefSettingPrivate.cpp
@@ -99,7 +99,8 @@ QCefSettingPrivate::CopyToCefBrowserSettings(const QCefSetting* qs, CefBrowserSe
 
   if (!qs) {
     QCefSettingPrivate defaultSettings;
-    cs->background_color = qs->d_ptr->backgroundColor_.value<QColor>().rgba();
+    cs->background_color = defaultSettings.backgroundColor_.value<QColor>().rgba();
+    return;
   }
 
   if (!qs->d_ptr->standardFontFamily_.empty())


### PR DESCRIPTION
修复使用 [ `QCefView::QCefView(QWidget* parent /*= 0*/)` ](https://github.com/CefView/QCefView/blob/main/src/QCefView.cpp#L31) 构造函数时，`CopyToCefBrowserSettings` 内的 NPE 问题。