### PR TITLE
Adapt cef 106

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/$<CONFIG>/lib)
 # Include CefViewCore
 add_subdirectory(CefViewCore)
 set_target_properties(CefViewCore PROPERTIES FOLDER core)
+add_compile_definitions(CEF_VERSION_MAJOR=${CEF_VERSION})
 
 foreach(CefViewWingTarget ${CefViewCore_HELPER_APP_TARGETS})
   set_target_properties(${CefViewWingTarget} PROPERTIES FOLDER core)

--- a/example/QCefViewTest/CMakeLists.txt
+++ b/example/QCefViewTest/CMakeLists.txt
@@ -27,6 +27,7 @@ file(WRITE ${CMAKE_BINARY_DIR}/auto_rebuild.cpp "/* Auto Rebuild Trigger */")
 
 include_directories(
   ${CMAKE_SOURCE_DIR}/include
+  ${CefViewCore_EXPORT_INCLUDE_PATH}
 )
 
 file(GLOB _SRC_FILES

--- a/example/QCefViewTest/CMakeLists.txt
+++ b/example/QCefViewTest/CMakeLists.txt
@@ -27,7 +27,6 @@ file(WRITE ${CMAKE_BINARY_DIR}/auto_rebuild.cpp "/* Auto Rebuild Trigger */")
 
 include_directories(
   ${CMAKE_SOURCE_DIR}/include
-  ${CefViewCore_EXPORT_INCLUDE_PATH}
 )
 
 file(GLOB _SRC_FILES

--- a/example/QCefViewTest/MainWindow.cpp
+++ b/example/QCefViewTest/MainWindow.cpp
@@ -55,7 +55,11 @@ MainWindow::createCefView()
   ///*
   // build settings for per QCefView
   QCefSetting setting;
+  
+  #if CEF_VERSION_MAJOR < 100
   setting.setPlugins(false);
+  #endif
+  
   setting.setWindowlessFrameRate(60);
   setting.setBackgroundColor(QColor::fromRgba(qRgba(255, 255, 220, 255)));
   // setting.setBackgroundColor(Qt::blue);

--- a/include/QCefSetting.h
+++ b/include/QCefSetting.h
@@ -274,11 +274,11 @@ public:
   /// <param name="value">True to enalbe; false to disable</param>
   void setPlugins(const bool value);
 
-  /// <summary>
-  /// Gets whether to enable or disable plugins
-  /// </summary>
-  /// <returns>True to enalbe; false to disable</returns>
-  const QVariant plugins() const;
+  ///// <summary>
+  ///// Gets whether to enable or disable plugins
+  ///// </summary>
+  ///// <returns>True to enalbe; false to disable</returns>
+  //const QVariant plugins() const;
 
   /// <summary>
   /// Sets to enable or disable the permission of loading images

--- a/include/QCefSetting.h
+++ b/include/QCefSetting.h
@@ -17,6 +17,10 @@
 #include <QString>
 #pragma endregion qt_headers
 
+#pragma region cef_headers
+#include <include/cef_version.h>
+#pragma endregion cef_headers
+
 class QCefSettingPrivate;
 
 /// <summary>

--- a/include/QCefSetting.h
+++ b/include/QCefSetting.h
@@ -268,17 +268,19 @@ public:
   /// <returns>True to enalbe; false to disable</returns>
   const QVariant javascriptDomPaste() const;
 
+  #if CEF_VERSION_MAJOR < 100
   /// <summary>
   /// Sets to enable or disable plugins
   /// </summary>
   /// <param name="value">True to enalbe; false to disable</param>
   void setPlugins(const bool value);
 
-  ///// <summary>
-  ///// Gets whether to enable or disable plugins
-  ///// </summary>
-  ///// <returns>True to enalbe; false to disable</returns>
-  //const QVariant plugins() const;
+  /// <summary>
+  /// Gets whether to enable or disable plugins
+  /// </summary>
+  /// <returns>True to enalbe; false to disable</returns>
+  const QVariant plugins() const;
+  #endif
 
   /// <summary>
   /// Sets to enable or disable the permission of loading images

--- a/include/QCefSetting.h
+++ b/include/QCefSetting.h
@@ -17,9 +17,7 @@
 #include <QString>
 #pragma endregion qt_headers
 
-#pragma region cef_headers
-#include <include/cef_version.h>
-#pragma endregion cef_headers
+
 
 class QCefSettingPrivate;
 

--- a/src/QCefSetting.cpp
+++ b/src/QCefSetting.cpp
@@ -276,19 +276,21 @@ QCefSetting::javascriptDomPaste() const
   return d->javascriptDomPaste_;
 }
 
+#if CEF_VERSION_MAJOR < 100
 void
 QCefSetting::setPlugins(const bool value)
 {
   Q_D(QCefSetting);
-  //d->plugins_ = value;
+  d->plugins_ = value;
 }
 
-//const QVariant
-//QCefSetting::plugins() const
-//{
-//  Q_D(const QCefSetting);
-//  //return d->plugins_;
-//}
+const QVariant
+QCefSetting::plugins() const
+{
+  Q_D(const QCefSetting);
+  return d->plugins_;
+}
+#endif
 
 void
 QCefSetting::setImageLoading(const bool value)

--- a/src/QCefSetting.cpp
+++ b/src/QCefSetting.cpp
@@ -280,15 +280,15 @@ void
 QCefSetting::setPlugins(const bool value)
 {
   Q_D(QCefSetting);
-  d->plugins_ = value;
+  //d->plugins_ = value;
 }
 
-const QVariant
-QCefSetting::plugins() const
-{
-  Q_D(const QCefSetting);
-  return d->plugins_;
-}
+//const QVariant
+//QCefSetting::plugins() const
+//{
+//  Q_D(const QCefSetting);
+//  //return d->plugins_;
+//}
 
 void
 QCefSetting::setImageLoading(const bool value)

--- a/src/details/QCefDownloadItemPrivate.cpp
+++ b/src/details/QCefDownloadItemPrivate.cpp
@@ -1,7 +1,6 @@
 ﻿#include "QCefDownloadItemPrivate.h"
 
 #include <QCefDownloadItem.h>
-#include <include/cef_version.h>
 
 QSharedPointer<QCefDownloadItem>
 QCefDownloadItemPrivate::createQCefDownloadItem(CCefClientDelegate::RefPtr handler,

--- a/src/details/QCefDownloadItemPrivate.cpp
+++ b/src/details/QCefDownloadItemPrivate.cpp
@@ -1,6 +1,7 @@
 ﻿#include "QCefDownloadItemPrivate.h"
 
 #include <QCefDownloadItem.h>
+#include <include/cef_version.h>
 
 QSharedPointer<QCefDownloadItem>
 QCefDownloadItemPrivate::createQCefDownloadItem(CCefClientDelegate::RefPtr handler,
@@ -24,12 +25,19 @@ QCefDownloadItemPrivate::createQCefDownloadItem(CCefClientDelegate::RefPtr handl
   double t = 0;
   cef_time_t ct;
 
+  #if CEF_VERSION_MAJOR >= 104
   cef_time_from_basetime(cefItem.GetStartTime(), &ct);
-
+  #else
+  ct = cefItem.GetStartTime();
+  #endif
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->startTime = QDateTime::fromSecsSinceEpoch(t);
 
+  #if CEF_VERSION_MAJOR >= 104
   cef_time_from_basetime(cefItem.GetEndTime(), &ct);
+  #else
+  ct = cefItem.GetEndTime();
+  #endif
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->endTime = QDateTime::fromSecsSinceEpoch(t);
 
@@ -63,11 +71,19 @@ QCefDownloadItemPrivate::updateDownloadItem(QCefDownloadItem* p,
   double t = 0;
   cef_time_t ct;
 
+  #if CEF_VERSION_MAJOR >= 104
   cef_time_from_basetime(cefItem.GetStartTime(), &ct);
+  #else
+  ct = cefItem.GetStartTime();
+  #endif
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->startTime = QDateTime::fromSecsSinceEpoch(t);
 
+  #if CEF_VERSION_MAJOR >= 104
   cef_time_from_basetime(cefItem.GetEndTime(), &ct);
+  #else
+  ct = cefItem.GetEndTime();
+  #endif
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->endTime = QDateTime::fromSecsSinceEpoch(t);
 

--- a/src/details/QCefDownloadItemPrivate.cpp
+++ b/src/details/QCefDownloadItemPrivate.cpp
@@ -24,11 +24,12 @@ QCefDownloadItemPrivate::createQCefDownloadItem(CCefClientDelegate::RefPtr handl
   double t = 0;
   cef_time_t ct;
 
-  ct = cefItem.GetStartTime();
+  cef_time_from_basetime(cefItem.GetStartTime(), &ct);
+
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->startTime = QDateTime::fromSecsSinceEpoch(t);
 
-  ct = cefItem.GetEndTime();
+  cef_time_from_basetime(cefItem.GetEndTime(), &ct);
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->endTime = QDateTime::fromSecsSinceEpoch(t);
 
@@ -62,11 +63,11 @@ QCefDownloadItemPrivate::updateDownloadItem(QCefDownloadItem* p,
   double t = 0;
   cef_time_t ct;
 
-  ct = cefItem.GetStartTime();
+  cef_time_from_basetime(cefItem.GetStartTime(), &ct);
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->startTime = QDateTime::fromSecsSinceEpoch(t);
 
-  ct = cefItem.GetEndTime();
+  cef_time_from_basetime(cefItem.GetEndTime(), &ct);
   if (cef_time_to_doublet(&ct, &t))
     p->d_ptr->endTime = QDateTime::fromSecsSinceEpoch(t);
 

--- a/src/details/QCefSettingPrivate.cpp
+++ b/src/details/QCefSettingPrivate.cpp
@@ -63,9 +63,11 @@ QCefSettingPrivate::CopyFromCefBrowserSettings(QCefSetting* qs, const CefBrowser
 
   if (cs->javascript_dom_paste != STATE_DEFAULT)
     qs->d_ptr->javascriptDomPaste_ = cs->javascript_dom_paste == STATE_ENABLED;
-  
-  //if (cs->plugins != STATE_DEFAULT)
-  //  qs->d_ptr->plugins_ = cs->plugins == STATE_ENABLED;
+
+  #if CEF_VERSION_MAJOR < 100
+  if (cs->plugins != STATE_DEFAULT)
+    qs->d_ptr->plugins_ = cs->plugins == STATE_ENABLED;
+  #endif
 
   if (cs->image_loading != STATE_DEFAULT)
     qs->d_ptr->imageLoading_ = cs->image_loading == STATE_ENABLED;
@@ -157,8 +159,10 @@ QCefSettingPrivate::CopyToCefBrowserSettings(const QCefSetting* qs, CefBrowserSe
   if (qs->d_ptr->javascriptDomPaste_.canConvert<bool>())
     cs->javascript_dom_paste = qs->d_ptr->javascriptDomPaste_.toBool() ? STATE_ENABLED : STATE_DISABLED;
 
-  //if (qs->d_ptr->plugins_.canConvert<bool>())
-  //  cs->plugins = qs->d_ptr->plugins_.toBool() ? STATE_ENABLED : STATE_DISABLED;
+  #if CEF_VERSION_MAJOR < 100
+  if (qs->d_ptr->plugins_.canConvert<bool>())
+    cs->plugins = qs->d_ptr->plugins_.toBool() ? STATE_ENABLED : STATE_DISABLED;
+  #endif
 
   if (qs->d_ptr->imageLoading_.canConvert<bool>())
     cs->image_loading = qs->d_ptr->imageLoading_.toBool() ? STATE_ENABLED : STATE_DISABLED;

--- a/src/details/QCefSettingPrivate.cpp
+++ b/src/details/QCefSettingPrivate.cpp
@@ -63,9 +63,9 @@ QCefSettingPrivate::CopyFromCefBrowserSettings(QCefSetting* qs, const CefBrowser
 
   if (cs->javascript_dom_paste != STATE_DEFAULT)
     qs->d_ptr->javascriptDomPaste_ = cs->javascript_dom_paste == STATE_ENABLED;
-
-  if (cs->plugins != STATE_DEFAULT)
-    qs->d_ptr->plugins_ = cs->plugins == STATE_ENABLED;
+  
+  //if (cs->plugins != STATE_DEFAULT)
+  //  qs->d_ptr->plugins_ = cs->plugins == STATE_ENABLED;
 
   if (cs->image_loading != STATE_DEFAULT)
     qs->d_ptr->imageLoading_ = cs->image_loading == STATE_ENABLED;
@@ -157,8 +157,8 @@ QCefSettingPrivate::CopyToCefBrowserSettings(const QCefSetting* qs, CefBrowserSe
   if (qs->d_ptr->javascriptDomPaste_.canConvert<bool>())
     cs->javascript_dom_paste = qs->d_ptr->javascriptDomPaste_.toBool() ? STATE_ENABLED : STATE_DISABLED;
 
-  if (qs->d_ptr->plugins_.canConvert<bool>())
-    cs->plugins = qs->d_ptr->plugins_.toBool() ? STATE_ENABLED : STATE_DISABLED;
+  //if (qs->d_ptr->plugins_.canConvert<bool>())
+  //  cs->plugins = qs->d_ptr->plugins_.toBool() ? STATE_ENABLED : STATE_DISABLED;
 
   if (qs->d_ptr->imageLoading_.canConvert<bool>())
     cs->image_loading = qs->d_ptr->imageLoading_.toBool() ? STATE_ENABLED : STATE_DISABLED;

--- a/src/details/QCefSettingPrivate.h
+++ b/src/details/QCefSettingPrivate.h
@@ -50,7 +50,7 @@ public:
   /* bool */ QVariant javascriptCloseWindows_;
   /* bool */ QVariant javascriptAccessClipboard_;
   /* bool */ QVariant javascriptDomPaste_;
-  /* bool */ QVariant plugins_;
+  /* bool */ //QVariant plugins_;
   /* bool */ QVariant imageLoading_;
   /* bool */ QVariant imageShrinkStandaloneToFit_;
   /* bool */ QVariant textAreaResize_;

--- a/src/details/QCefSettingPrivate.h
+++ b/src/details/QCefSettingPrivate.h
@@ -7,6 +7,7 @@
 
 #pragma region cef_headers
 #include <include/cef_app.h>
+#include <include/cef_version.h>
 #pragma endregion cef_headers
 
 #pragma region qt_headers
@@ -50,7 +51,9 @@ public:
   /* bool */ QVariant javascriptCloseWindows_;
   /* bool */ QVariant javascriptAccessClipboard_;
   /* bool */ QVariant javascriptDomPaste_;
-  /* bool */ //QVariant plugins_;
+  #if CEF_VERSION_MAJOR < 100
+  /* bool */ QVariant plugins_;
+  #endif
   /* bool */ QVariant imageLoading_;
   /* bool */ QVariant imageShrinkStandaloneToFit_;
   /* bool */ QVariant textAreaResize_;

--- a/src/details/QCefSettingPrivate.h
+++ b/src/details/QCefSettingPrivate.h
@@ -7,7 +7,6 @@
 
 #pragma region cef_headers
 #include <include/cef_app.h>
-#include <include/cef_version.h>
 #pragma endregion cef_headers
 
 #pragma region qt_headers


### PR DESCRIPTION
I adapted cef 106, so now the project can be built with latest cef 106 binary. Two breaking changes from cef are:
1. Add CefBaseTime and use it instead of CefTime (see issue #2935) Cef commit hash `27d308980414432ee69bdc16dae7cb16a6aaa2b9`
2. Delete cef_web_plugin.h and plugin-related APIs (see issue #3047) Cef commit hash `28c7f040016a0271ec2612cc5021599fb55a1054`