### PR TITLE
修复 QCefView.framework 无法被 codesign 的问题

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,18 +176,18 @@ if(OS_MACOS)
 
     # create plugins directory
     COMMAND mkdir -p
-    "$<TARGET_BUNDLE_DIR:QCefView>/PlugIns/"
+    "$<TARGET_BUNDLE_DIR:QCefView>/Resources/PlugIns/"
 
     # copy the CefViewCore binaries to resource directory
     COMMAND cp -a
     "$<TARGET_BUNDLE_DIR:CefViewWing>/../"
-    "$<TARGET_BUNDLE_DIR:QCefView>/PlugIns/"
+    "$<TARGET_BUNDLE_DIR:QCefView>/Resources/PlugIns/"
 
     # sign the cef framework
     COMMAND codesign
     --force
     --sign -
-    "$<TARGET_BUNDLE_DIR:QCefView>/PlugIns/Chromium Embedded Framework.framework"
+    "$<TARGET_BUNDLE_DIR:QCefView>/Resources/PlugIns/Chromium Embedded Framework.framework"
   )
 endif() # OS_MACOS
 

--- a/src/mac/details/QCefContextPrivate_mac.mm
+++ b/src/mac/details/QCefContextPrivate_mac.mm
@@ -15,6 +15,7 @@
 #define CEF_FRAMEWORK_NAME "Chromium Embedded Framework.framework"
 #define HELPER_BUNDLE_NAME "CefViewWing.app"
 #define HELPER_BINARY_NAME "CefViewWing"
+#define PLUGINS_NAME "PlugIns"
 
 @interface PathFactory : NSObject
 + (NSString*) AppMainBundlePath;
@@ -28,13 +29,15 @@
 }
 
 + (NSString*) CefFrameworkPath {
-  NSString* path = [[NSBundle bundleForClass:[PathFactory class]] builtInPlugInsPath];
+  NSString* path =  [[NSBundle bundleForClass:[PathFactory class]] resourcePath];
+  path = [path stringByAppendingPathComponent:@PLUGINS_NAME];
   path = [path stringByAppendingPathComponent:@CEF_FRAMEWORK_NAME];
   return path;
 }
 
 + (NSString*) CefSubprocessPath {
-  NSString* path = [[NSBundle bundleForClass:[PathFactory class]] builtInPlugInsPath];
+  NSString* path =  [[NSBundle bundleForClass:[PathFactory class]] resourcePath];
+  path = [path stringByAppendingPathComponent:@PLUGINS_NAME];
   path = [path stringByAppendingPathComponent:@HELPER_BUNDLE_NAME];
   path = [path stringByAppendingPathComponent:@"Contents"];
   path = [path stringByAppendingPathComponent:@"MacOS"];


### PR DESCRIPTION
问题：

在尝试使用 `codesign ... -v QCefView.framework` 时，会出现 `QCefView.framework: unsealed contents present in the root directory of an embedded framework` 的问题。


解决办法：

修改 QCefView.frameowk 的目录结构，将 `PlugIns` 目录放在 `Resources` 目录下。