### PR TITLE
feat: better QCefViewTest on MacOS

### DIFF
--- a/example/QCefViewTest/MainWindow.cpp
+++ b/example/QCefViewTest/MainWindow.cpp
@@ -1,4 +1,4 @@
-﻿#include "MainWindow.h"
+#include "MainWindow.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -19,6 +19,12 @@ MainWindow::MainWindow(QWidget* parent)
   : QMainWindow(parent /*, Qt::FramelessWindowHint*/)
 {
   ui.setupUi(this);
+
+#ifdef Q_OS_MACOS
+  this->ui.nativeContainer->setContentsMargins(0, 28, 0, 0);
+#endif
+
+  setupWindow();
 
   // setWindowFlags(Qt::FramelessWindowHint);
   // setAttribute(Qt::WA_TranslucentBackground);
@@ -292,3 +298,10 @@ MainWindow::onBtnNewBrowserClicked()
   w->resize(1024, 768);
   w->show();
 }
+
+#ifndef Q_OS_MACOS
+void
+MainWindow::setupWindow()
+{
+}
+#endif

--- a/example/QCefViewTest/MainWindow.h
+++ b/example/QCefViewTest/MainWindow.h
@@ -17,6 +17,7 @@ public:
 
 protected:
   void createCefView();
+  void setupWindow();
 
   // QCefView slots
 protected slots:

--- a/example/QCefViewTest/mac/MainWindow_mac.mm
+++ b/example/QCefViewTest/mac/MainWindow_mac.mm
@@ -1,0 +1,14 @@
+#include "MainWindow.h"
+#include <Cocoa/Cocoa.h>
+
+void
+MainWindow::setupWindow() {
+    [NSApp setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+    
+    id hwnd = (id)this->winId();
+    NSWindow* window = [hwnd window];
+    window.titlebarAppearsTransparent = true;
+    [window setTitle: @""];
+    window.movableByWindowBackground = true;
+    window.styleMask |= NSWindowStyleMaskFullSizeContentView;
+}


### PR DESCRIPTION
优化 MacOS 上的 demo:

- 强制使用浅色模式，避免系统深色模式下 demo 界面问题
- 增加 `NSWindow` 自定义样式 demo

旧界面：
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/3633972/210915203-01b6ff3b-c119-4c1a-afa6-daa8355f835b.png">


新界面：
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/3633972/210915424-b6dc29f5-7a4c-4f8f-bb22-a9a28f836f92.png">
