### PR TITLE
Refactor of the popup browser implementation

### DIFF
--- a/example/QCefViewTest/CefViewWidget.cpp
+++ b/example/QCefViewTest/CefViewWidget.cpp
@@ -53,42 +53,17 @@ CefViewWidget::updateMask()
   setMask(mask);
 }
 
-
 bool
 CefViewWidget::onBeforePopup(qint64 frameId,
                              const QString& targetUrl,
                              const QString& targetFrameName,
                              QCefView::CefWindowOpenDisposition targetDisposition,
-                             QCefSetting& settings,
-                             bool& DisableJavascriptAccess)
+                             QRect& rect,
+                             QCefSetting& settings)
 {
-  qDebug() << "onBeforePopup\n"
-           << "frameId:" << frameId << "\n "
-           << "targetUrl:" << targetUrl << "\n"
-           << "targetFrameName:" << targetFrameName;
-
-  // return true to disallow the popup browser
-  // return true;
-
-  // here we can modify the settings for the popup browsers
+  // create new QCefView as popup browser
   settings.setBackgroundColor(Qt::red);
-
-  // return false to allow the popup browser
   return false;
-}
-
-void
-CefViewWidget::onPopupCreated(QWindow* wnd)
-{
-  // customize the window style of the created popup browser
-  // This not recommended, because when this method gets called
-  // the popup browser window has been created and displayed already
-  // if you modify the window style and re-parent it, the window will
-  // get flicker quickly
-
-  // QWidget* popupWindow = QWidget::createWindowContainer(wnd, nullptr, Qt::Window);
-  // popupWindow->setAttribute(Qt::WA_DeleteOnClose, true);
-  // popupWindow->show();
 }
 
 void

--- a/example/QCefViewTest/CefViewWidget.h
+++ b/example/QCefViewTest/CefViewWidget.h
@@ -42,10 +42,8 @@ protected:
                      const QString& targetUrl,
                      const QString& targetFrameName,
                      QCefView::CefWindowOpenDisposition targetDisposition,
-                     QCefSetting& settings,
-                     bool& DisableJavascriptAccess) override;
-
-  void onPopupCreated(QWindow* wnd) override;
+                     QRect& rect,
+                     QCefSetting& settings) override;
 
   void onNewDownloadItem(const QSharedPointer<QCefDownloadItem>& item, const QString& suggestedName) override;
 

--- a/example/QCefViewTest/MainWindow.cpp
+++ b/example/QCefViewTest/MainWindow.cpp
@@ -280,6 +280,22 @@ MainWindow::onBtnNewBrowserClicked()
   w->show();
 }
 
+void
+MainWindow::closeEvent(QCloseEvent* event)
+{
+  if (m_pLeftCefViewWidget) {
+    m_pLeftCefViewWidget->deleteLater();
+    m_pLeftCefViewWidget = nullptr;
+  }
+
+  if (m_pRightCefViewWidget) {
+    m_pRightCefViewWidget->deleteLater();
+    m_pRightCefViewWidget = nullptr;
+  }
+
+  event->accept();
+}
+
 #ifndef Q_OS_MACOS
 void
 MainWindow::setupWindow()

--- a/example/QCefViewTest/MainWindow.h
+++ b/example/QCefViewTest/MainWindow.h
@@ -2,6 +2,7 @@
 #define QCEFVIEWTEST_H
 
 #include <QMainWindow>
+#include <QCloseEvent>
 
 #include "ui_MainWindow.h"
 
@@ -55,6 +56,9 @@ protected slots:
   void onBtnCallJSCodeClicked();
 
   void onBtnNewBrowserClicked();
+
+  private:
+  void closeEvent(QCloseEvent* event) override;
 
 private:
   Ui::MainWindow m_ui;

--- a/example/QCefViewTest/index.in.html
+++ b/example/QCefViewTest/index.in.html
@@ -60,29 +60,34 @@
   <body onload="onLoad()" id="main" class="noselect">
     <h1 align="center" style="font-size: 12pt">Web Area</h1>
     <div align="center">
-      <div style="background-color: green; -webkit-app-region: drag">
-        <h1>Dragging area</h1>
-      </div>
-      <br />
+        <div style="background-color: green; -webkit-app-region: drag">
+            <h1>Dragging area</h1>
+        </div>
+        <br />
 
-      <label> Test Case for InvokeMethod </label>
-      <br />
-      <input type="button" value="Invoke Method" onclick="testInvokeMethod()" />
-      <br />
-      <br />
+        <label> Test Case for InvokeMethod </label>
+        <br />
+        <input type="button" value="Invoke Method" onclick="testInvokeMethod()" />
+        <br />
+        <br />
 
-      <label> Test Case for QCefQuery </label>
-      <br />
-      <textarea id="message" style="width: 320px; height: 120px">
-this message will be processed by native code.</textarea
-      >
-      <br />
-      <input type="button" value="Query" onclick="onCallBridgeQueryClicked()" />
-      <br />
-      <br />
+        <label> Test Case for QCefQuery </label>
+        <br />
+        <textarea id="message" style="width: 320px; height: 120px">
+this message will be processed by native code.</textarea>
+        <br />
+        <input type="button" value="Query" onclick="onCallBridgeQueryClicked()" />
+        <br />
+        <br />
 
-      <p>An iframe with default borders:</p>
-      <iframe src="/tutorial.html" width="100%" height="300"> </iframe>
+        <label> Test Case for Popup Browser </label>
+        <br />
+        <a href="#" target="_blank">Popup Browser By HTML</a>
+        <br />
+        <a href="#" onClick="window.open('#','QCefView Popup','width=800, height=600'); return false;">Popup Browser By Script</a>
+
+        <p>An iframe with default borders:</p>
+        <iframe src="/tutorial.html" width="100%" height="300"> </iframe>
     </div>
   </body>
 </html>

--- a/include/QCefView.h
+++ b/include/QCefView.h
@@ -66,13 +66,13 @@ public:
   /// <param name="url">The target url</param>
   /// <param name="setting">The <see cref="QCefSetting"/> instance</param>
   /// <param name="parent">The parent</param>
-  QCefView(const QString url, const QCefSetting* setting, QWidget* parent = 0);
+  QCefView(const QString url, const QCefSetting* setting, QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
 
   /// <summary>
   /// Constructs a QCefView instance
   /// </summary>
   /// <param name="parent">The parent</param>
-  QCefView(QWidget* parent = 0);
+  QCefView(QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
 
   /// <summary>
   /// Destructs the QCefView instance
@@ -101,6 +101,12 @@ public:
   /// </summary>
   /// <returns>The browser id</returns>
   int browserId();
+
+  /// <summary>
+  /// Gets whether the browser is created as popup browser
+  /// </summary>
+  /// <returns>True if it is popup browser; otherwise false</returns>
+  bool isPopup();
 
   /// <summary>
   /// Navigates to the content.
@@ -359,13 +365,26 @@ signals:
   /// <param name="result">The result</param>
   void reportJavascriptResult(int browserId, qint64 frameId, qint64 context, const QVariant& result);
 
-public slots:
   /// <summary>
   /// Gets called after the main browser window created. This slot does not work for OSR mode.
   /// </summary>
   /// <param name="win">The CEF window</param>
-  virtual void onBrowserWindowCreated(QWindow* win);
+  void browserCreated(QCefView* browser);
 
+  /// <summary>
+  /// Gets called right after the popup browser was created.
+  /// </summary>
+  /// <param name="wnd">The new created popup QCefView instance</param>
+  /// <remarks>
+  /// The lifecycle of the popup browser is managed by the owner of the popup browser,
+  /// thus do not try to hold the popup browser instance.
+  /// If you need to implement browser tab, you should override the <see cref="onBeforePopup"/> method
+  /// and create your own QCefView browser instance then you can manipulate the created one as whatever
+  /// you want.
+  /// </remarks>
+  void popupCreated(QCefView* popup);
+
+protected:
   /// <summary>
   /// Gets called before the popup browser created
   /// </summary>
@@ -374,21 +393,14 @@ public slots:
   /// <param name="targetFrameName">The target name</param>
   /// <param name="targetDisposition">Target window open method</param>
   /// <param name="settings">Settings to be used for the popup</param>
-  /// <param name="DisableJavascriptAccess">Disable the access to Javascript</param>
+  /// <param name="rect">Rect to be used for the popup</param>
   /// <returns>True to cancel the popup; false to allow</returns>
   virtual bool onBeforePopup(qint64 frameId,
                              const QString& targetUrl,
                              const QString& targetFrameName,
                              QCefView::CefWindowOpenDisposition targetDisposition,
-                             QCefSetting& settings,
-                             bool& DisableJavascriptAccess);
-
-protected:
-  /// <summary>
-  /// Gets called right after the popup browser was created.
-  /// </summary>
-  /// <param name="wnd">The host window of new created popup browser</param>
-  virtual void onPopupCreated(QWindow* wnd);
+                             QRect& rect,
+                             QCefSetting& settings);
 
   /// <summary>
   /// Gets called on new download item was required. Keep reference to the download item

--- a/src/QCefView.cpp
+++ b/src/QCefView.cpp
@@ -15,8 +15,11 @@
 #include "details/QCefViewPrivate.h"
 #include "details/utils/CommonUtils.h"
 
-QCefView::QCefView(const QString url, const QCefSetting* setting, QWidget* parent /*= 0*/)
-  : QWidget(parent)
+QCefView::QCefView(const QString url,
+                   const QCefSetting* setting,
+                   QWidget* parent /*= 0*/,
+                   Qt::WindowFlags f /*= Qt::WindowFlags()*/)
+  : QWidget(parent, f)
   , d_ptr(new QCefViewPrivate(QCefContext::instance()->d_func(), this, url, setting))
 {
   // #if defined(CEF_USE_OSR)
@@ -33,8 +36,8 @@ QCefView::QCefView(const QString url, const QCefSetting* setting, QWidget* paren
   d_ptr->createCefBrowser(this, url, setting);
 }
 
-QCefView::QCefView(QWidget* parent /*= 0*/)
-  : QCefView("about:blank", nullptr, parent)
+QCefView::QCefView(QWidget* parent /*= 0*/, Qt::WindowFlags f /*= Qt::WindowFlags()*/)
+  : QCefView("about:blank", nullptr, parent, f)
 {
 }
 
@@ -43,6 +46,10 @@ QCefView::~QCefView()
   qDebug() << this << "is being destructed";
 
   if (d_ptr) {
+    // close all popup browsers
+    d_ptr->closeAllPopupBrowsers();
+
+    // destroy under layer cef browser
     d_ptr->destroyCefBrowser();
     d_ptr.reset();
   }
@@ -73,6 +80,15 @@ QCefView::browserId()
   Q_D(QCefView);
 
   return d->browserId();
+}
+
+
+bool
+QCefView::isPopup()
+{
+  Q_D(QCefView);
+
+  return d->isPopup();
 }
 
 void
@@ -227,26 +243,15 @@ QCefView::setFocus(Qt::FocusReason reason)
   d->setCefWindowFocus(true);
 }
 
-void
-QCefView::onBrowserWindowCreated(QWindow* win)
-{
-}
-
 bool
 QCefView::onBeforePopup(qint64 frameId,
                         const QString& targetUrl,
                         const QString& targetFrameName,
                         QCefView::CefWindowOpenDisposition targetDisposition,
-                        QCefSetting& settings,
-                        bool& DisableJavascriptAccess)
+                        QRect& rect,
+                        QCefSetting& settings)
 {
-  // return false to allow the popup browser
   return false;
-}
-
-void
-QCefView::onPopupCreated(QWindow* wnd)
-{
 }
 
 void

--- a/src/details/CCefClientDelegate.h
+++ b/src/details/CCefClientDelegate.h
@@ -94,7 +94,7 @@ public:
                              bool& DisableJavascriptAccess) override;
   virtual void onAfterCreate(CefRefPtr<CefBrowser>& browser) override;
   virtual bool doClose(CefRefPtr<CefBrowser> browser) override;
-  virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
+  virtual void onBeforeClose(CefRefPtr<CefBrowser> browser) override;
 
   // LoadHandler
   virtual void loadingStateChanged(CefRefPtr<CefBrowser>& browser,

--- a/src/details/CCefClientDelegate_LifeSpanHandler.cpp
+++ b/src/details/CCefClientDelegate_LifeSpanHandler.cpp
@@ -15,31 +15,22 @@ CCefClientDelegate::onBeforePopup(CefRefPtr<CefBrowser>& browser,
                                   CefBrowserSettings& settings,
                                   bool& DisableJavascriptAccess)
 {
-  bool result = false;
   if (pCefViewPrivate_) {
-    auto url = QString::fromStdString(targetUrl);
-    auto name = QString::fromStdString(targetFrameName);
 
-    QCefSetting s;
-    QCefView::CefWindowOpenDisposition d = (QCefView::CefWindowOpenDisposition)targetDisposition;
-    QCefSettingPrivate::CopyFromCefBrowserSettings(&s, &settings);
+    Qt::ConnectionType c =
+      pCefViewPrivate_->q_ptr->thread() == QThread::currentThread() ? Qt::DirectConnection : Qt::QueuedConnection;
 
-    Qt::ConnectionType c = pCefViewPrivate_->q_ptr->thread() == QThread::currentThread() ? Qt::DirectConnection
-                                                                                         : Qt::BlockingQueuedConnection;
-    QMetaObject::invokeMethod(pCefViewPrivate_->q_ptr,
-                              "onBeforePopup",                              //
-                              c,                                            //
-                              Q_RETURN_ARG(bool, result),                   //
-                              Q_ARG(qint64, frameId),                       //
-                              Q_ARG(const QString&, url),                   //
-                              Q_ARG(const QString&, name),                  //
-                              Q_ARG(QCefView::CefWindowOpenDisposition, d), //
-                              Q_ARG(QCefSetting&, s),                       //
-                              Q_ARG(bool&, DisableJavascriptAccess)         //
-    );
-    QCefSettingPrivate::CopyToCefBrowserSettings(&s, &settings);
+    QMetaObject::invokeMethod(
+      pCefViewPrivate_,
+      [=]() {
+        pCefViewPrivate_->onBeforeCefPopupCreate(
+          browser, frameId, targetUrl, targetFrameName, targetDisposition, windowInfo, settings);
+      },
+      c);
   }
-  return result;
+
+  // QCefView doesn't use CEF built-in popup browser
+  return true;
 }
 
 void
@@ -77,11 +68,7 @@ CCefClientDelegate::onAfterCreate(CefRefPtr<CefBrowser>& browser)
   QMetaObject::invokeMethod(
     pCefViewPrivate_,
     [=]() {
-      CefRefPtr<CefBrowser> b(browser);
-      if (b->IsPopup())
-        pCefViewPrivate_->onCefPopupBrowserCreated(b, w);
-      else
-        pCefViewPrivate_->onCefMainBrowserCreated(b, w);
+      pCefViewPrivate_->onCefBrowserCreated(browser, w);
     },
     c);
 }
@@ -93,7 +80,7 @@ CCefClientDelegate::doClose(CefRefPtr<CefBrowser> browser)
 }
 
 void
-CCefClientDelegate::OnBeforeClose(CefRefPtr<CefBrowser> browser)
+CCefClientDelegate::onBeforeClose(CefRefPtr<CefBrowser> browser)
 {
   return;
 }

--- a/src/details/QCefViewPrivate.h
+++ b/src/details/QCefViewPrivate.h
@@ -39,6 +39,11 @@ public:
   static void destroyAllInstance();
 
   /// <summary>
+  /// 
+  /// </summary>
+  bool isPopup_ = false;
+
+  /// <summary>
   ///
   /// </summary>
   bool disablePopuContextMenu_ = false;
@@ -155,6 +160,11 @@ public:
   QElapsedTimer paintTimer_;
 #endif
 
+  /// <summary>
+  /// The list of popup child-browsers of this browser.
+  /// </summary>
+  QSet<QCefView*> popupBrowsers_;
+
 public:
   explicit QCefViewPrivate(QCefContextPrivate* ctx,
                            QCefView* view,
@@ -167,6 +177,8 @@ public:
 
   void destroyCefBrowser();
 
+  void closeAllPopupBrowsers();
+
   void addLocalFolderResource(const QString& path, const QString& url, int priority = 0);
 
   void addArchiveResource(const QString& path, const QString& url, const QString& password = "", int priority = 0);
@@ -176,9 +188,15 @@ public:
   bool isOSRModeEnabled() const;
 
 protected:
-  void onCefMainBrowserCreated(CefRefPtr<CefBrowser>& browser, QWindow* window);
+  void onCefBrowserCreated(CefRefPtr<CefBrowser> browser, QWindow* window);
 
-  void onCefPopupBrowserCreated(CefRefPtr<CefBrowser>& browser, QWindow* window);
+  void onBeforeCefPopupCreate(const CefRefPtr<CefBrowser>& browser,
+                              int64_t frameId,
+                              const std::string& targetUrl,
+                              const std::string& targetFrameName,
+                              CefLifeSpanHandler::WindowOpenDisposition targetDisposition,
+                              const CefWindowInfo& windowInfo,
+                              const CefBrowserSettings& settings);
 
   void onNewDownloadItem(QSharedPointer<QCefDownloadItem> item, const QString& suggestedName);
 
@@ -191,6 +209,10 @@ protected:
                        const std::string& failedUrl);
 
 public slots:
+  void onPopupBrowserCreated(QCefView* popup);
+
+  void onPopupBrowserDestroyed(QObject* popup);
+
   void onAppFocusChanged(QWidget* old, QWidget* now);
 
   void onViewScreenChanged(QScreen* screen);
@@ -250,6 +272,8 @@ protected:
 
 public:
   int browserId();
+
+  bool isPopup();
 
   void navigateToString(const QString& content);
 


### PR DESCRIPTION
- Disabled CEF built-in popup browser
- Create new QCefView browser instance as popup browser
- Popup browser is managed by the owner (source browser which opens the popup)