### PR TITLE
some improve

### DIFF
--- a/include/QCefView.h
+++ b/include/QCefView.h
@@ -67,14 +67,14 @@ public:
   /// <param name="setting">The <see cref="QCefSetting"/> instance</param>
   /// <param name="parent">The parent</param>
   /// <param name="f">The Qt WindowFlags</param>
-  QCefView(const QString url, const QCefSetting* setting, QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
+  QCefView(const QString url, const QCefSetting* setting, QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
   /// <summary>
   /// Constructs a QCefView instance
   /// </summary>
   /// <param name="parent">The parent</param>
   /// <param name="f">The Qt WindowFlags</param>
-  QCefView(QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
+  QCefView(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
   /// <summary>
   /// Destructs the QCefView instance

--- a/src/details/QCefViewPrivate.cpp
+++ b/src/details/QCefViewPrivate.cpp
@@ -86,7 +86,7 @@ QCefViewPrivate::createCefBrowser(QCefView* view, const QString url, const QCefS
   CefWindowInfo window_info;
   // #if defined(CEF_USE_OSR)
   if (isOSRModeEnabled_) {
-    window_info.SetAsWindowless(nullptr);
+    window_info.SetAsWindowless(0);
   } else { // #else
 #if defined(OS_LINUX)
     // Don't know why, on Linux platform if we use QCefView's winId() as

--- a/src/details/QCefViewPrivate.cpp
+++ b/src/details/QCefViewPrivate.cpp
@@ -9,7 +9,6 @@
 #include <QDebug>
 #include <QInputMethodQueryEvent>
 #include <QPainter>
-#include <QPlatformSurfaceEvent>
 #include <QVBoxLayout>
 #include <QWindow>
 #pragma endregion qt_headers
@@ -87,7 +86,7 @@ QCefViewPrivate::createCefBrowser(QCefView* view, const QString url, const QCefS
   CefWindowInfo window_info;
   // #if defined(CEF_USE_OSR)
   if (isOSRModeEnabled_) {
-    window_info.SetAsWindowless(0);
+    window_info.SetAsWindowless(nullptr);
   } else { // #else
 #if defined(OS_LINUX)
     // Don't know why, on Linux platform if we use QCefView's winId() as
@@ -137,7 +136,6 @@ QCefViewPrivate::createCefBrowser(QCefView* view, const QString url, const QCefS
 
   pClient_ = pClient;
   pClientDelegate_ = pClientDelegate;
-  return;
 }
 
 void
@@ -322,8 +320,6 @@ QCefViewPrivate::onBeforeCefPopupCreate(const CefRefPtr<CefBrowser>& browser,
   }
   popup->setAttribute(Qt::WA_DeleteOnClose, true);
   popup->resize(rc.size());
-
-  return;
 }
 
 void
@@ -755,7 +751,7 @@ QCefViewPrivate::onViewInputMethodEvent(QInputMethodEvent* event)
     } else if (!composingText.isEmpty()) {
       CefCompositionUnderline underline;
       underline.background_color = 0;
-      underline.range = { 0, (int)composingText.length() };
+      underline.range = { 0, static_cast<decltype(CefRange::to)>(composingText.length()) };
 
       CefRange selectionRange;
       for (auto& attr : event->attributes()) {

--- a/src/details/QCefViewPrivate.h
+++ b/src/details/QCefViewPrivate.h
@@ -256,7 +256,7 @@ protected:
   void closeDevTools();
 
 protected:
-  virtual bool eventFilter(QObject* watched, QEvent* event) override;
+  bool eventFilter(QObject* watched, QEvent* event) override;
 
   QVariant onViewInputMethodQuery(Qt::InputMethodQuery query) const;
 


### PR DESCRIPTION
1. Redundant return statement at the end of a function with a void return type.
2. use nullptr instead of 0
3. Use explicit type conversion and automatic type deduction to avoid type differences in future versions.