### PR TITLE
Fix popup window logic -  use CEF built-in popup management

### DIFF
--- a/example/QCefViewTest/CefViewWidget.cpp
+++ b/example/QCefViewTest/CefViewWidget.cpp
@@ -59,7 +59,8 @@ CefViewWidget::onBeforePopup(qint64 frameId,
                              const QString& targetFrameName,
                              QCefView::CefWindowOpenDisposition targetDisposition,
                              QRect& rect,
-                             QCefSetting& settings)
+                             QCefSetting& settings,
+                             bool& disableJavascript)
 {
   // create new QCefView as popup browser
   settings.setBackgroundColor(Qt::red);

--- a/example/QCefViewTest/CefViewWidget.h
+++ b/example/QCefViewTest/CefViewWidget.h
@@ -35,7 +35,8 @@ protected:
                      const QString& targetFrameName,
                      QCefView::CefWindowOpenDisposition targetDisposition,
                      QRect& rect,
-                     QCefSetting& settings) override;
+                     QCefSetting& settings,
+                     bool& disableJavascript) override;
 
   void onNewDownloadItem(const QSharedPointer<QCefDownloadItem>& item, const QString& suggestedName) override;
 

--- a/example/QCefViewTest/MainWindow.cpp
+++ b/example/QCefViewTest/MainWindow.cpp
@@ -102,7 +102,7 @@ MainWindow::createRightCefView()
 
   // this site is for test web events
   m_pRightCefViewWidget = new CefViewWidget("", &setting, this);
-  m_pRightCefViewWidget->navigateToUrl("https://fastest.fish/test-files");
+  m_pRightCefViewWidget->navigateToUrl("https://www.javatpoint.com/oprweb/test.jsp?filename=javascript-window-close-method1");
 
   //
   // m_pRightCefViewWidget = new CefViewWidget("https://mdn.dev/", &setting, this);

--- a/include/QCefView.h
+++ b/include/QCefView.h
@@ -77,7 +77,7 @@ public:
   /// </summary>
   /// <param name="parent">The parent</param>
   /// <param name="f">The Qt WindowFlags</param>
-  QCefView(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+  explicit QCefView(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
 
   /// <summary>
   /// Destructs the QCefView instance
@@ -106,12 +106,6 @@ public:
   /// </summary>
   /// <returns>The browser id</returns>
   int browserId();
-
-  /// <summary>
-  /// Gets whether the browser is created as popup browser
-  /// </summary>
-  /// <returns>True if it is popup browser; otherwise false</returns>
-  bool isPopup();
 
   /// <summary>
   /// Navigates to the content.
@@ -408,19 +402,6 @@ signals:
   /// <param name="window">The native browser windows</param>
   void nativeBrowserCreated(QWindow* window);
 
-  /// <summary>
-  /// Gets called right after the popup browser was created.
-  /// </summary>
-  /// <param name="popup">The new created popup QCefView instance</param>
-  /// <remarks>
-  /// The lifecycle of the popup browser is managed by the owner of the popup browser,
-  /// thus do not try to hold the popup browser instance.
-  /// If you need to implement browser tab, you should override the <see cref="onBeforePopup"/> method
-  /// and create your own QCefView browser instance then you can manipulate the created one as whatever
-  /// you want.
-  /// </remarks>
-  void popupCreated(QCefView* popup);
-
 protected:
   /// <summary>
   /// Gets called before the popup browser created
@@ -437,7 +418,21 @@ protected:
                              const QString& targetFrameName,
                              QCefView::CefWindowOpenDisposition targetDisposition,
                              QRect& rect,
-                             QCefSetting& settings);
+                             QCefSetting& settings,
+                             bool& disableJavascript);
+
+  /// <summary>
+  /// Gets called right after the popup browser was created.
+  /// </summary>
+  /// <param name="popup">The new created popup QCefView instance</param>
+  /// <remarks>
+  /// The lifecycle of the popup browser is managed by the owner of the popup browser,
+  /// thus do not try to hold the popup browser instance.
+  /// If you need to implement browser tab, you should override the <see cref="onBeforePopup"/> method
+  /// and create your own QCefView browser instance then you can manipulate the created one as whatever
+  /// you want.
+  /// </remarks>
+  void onPopupCreated(QWidget* popup, const QString& url, const QString& name);
 
   /// <summary>
   /// Gets called on new download item was required. Keep reference to the download item

--- a/src/details/CCefClientDelegate.h
+++ b/src/details/CCefClientDelegate.h
@@ -141,7 +141,7 @@ public:
                              CefLifeSpanHandler::WindowOpenDisposition targetDisposition,
                              CefWindowInfo& windowInfo,
                              CefBrowserSettings& settings,
-                             bool& DisableJavascriptAccess) override;
+                             bool& disableJavascriptAccess) override;
   virtual void onAfterCreate(CefRefPtr<CefBrowser>& browser) override;
   virtual bool doClose(CefRefPtr<CefBrowser> browser) override;
   virtual void onBeforeClose(CefRefPtr<CefBrowser> browser) override;


### PR DESCRIPTION
- 重新实现popup browser的逻辑
- 使用CEF内置的popup 生命周期管理逻辑
- onBeforePopup 方法提供允许/禁止弹出窗口的拦截时机，可以重载该函数，返回true/false来控制，以及在该方法内设置一些参数
- onPopupCreated 方法提供自定义已经弹出的popup browser的能力
