### PR TITLE
fix: remove QCefConfig.userDataPath if using CEF version 115

### DIFF
--- a/include/QCefConfig.h
+++ b/include/QCefConfig.h
@@ -191,6 +191,10 @@ public:
   /// <summary>
   /// Sets the user data directory path
   /// </summary>
+  /// <remarks>
+  /// Not available after cef version 115. See
+  /// https://github.com/chromiumembedded/cef/commit/b5386249bd9075982db0874d3a981c44adc4c420
+  /// </remarks>
   /// <param name="path">The user data directory path</param>
   void setUserDataPath(const QString& path);
 

--- a/include/QCefConfig.h
+++ b/include/QCefConfig.h
@@ -188,6 +188,7 @@ public:
   /// </summary>
   const QString cachePath() const;
 
+#if CEF_VERSION_MAJOR < 115
   /// <summary>
   /// Sets the user data directory path
   /// </summary>
@@ -202,6 +203,7 @@ public:
   /// Gets the user data directory path
   /// </summary>
   const QString userDataPath() const;
+#endif
 
   /// <summary>
   /// Sets the bridge object name

--- a/src/details/QCefConfigPrivate.cpp
+++ b/src/details/QCefConfigPrivate.cpp
@@ -72,8 +72,10 @@ QCefConfigPrivate::CopyToCefSettings(const QCefConfig* config, CefSettings* sett
   if (!config->d_ptr->cachePath_.empty())
     CefString(&settings->cache_path) = config->d_ptr->cachePath_;
 
+#if CEF_VERSION_MAJOR < 115
   if (!config->d_ptr->userDataPath_.empty())
     CefString(&settings->user_data_path) = config->d_ptr->userDataPath_;
+#endif
 
   if (!config->d_ptr->locale_.empty())
     CefString(&settings->locale) = config->d_ptr->locale_;


### PR DESCRIPTION
See [Remove CefSettings.user_data_path](https://github.com/chromiumembedded/cef/commit/b5386249bd9075982db0874d3a981c44adc4c420)