### PR TITLE
Fix bug: When saving a file in Linux, the file name extension is not …

### DIFF
--- a/src/details/QCefViewPrivate.h
+++ b/src/details/QCefViewPrivate.h
@@ -317,4 +317,6 @@ public:
   bool sendEventNotifyMessage(int64_t frameId, const QString& name, const QVariantList& args);
 
   bool setPreference(const QString& name, const QVariant& value, const QString& error);
+private:
+  QString addExtensionIfNeeded(const QString &filePath, const QString &selectedFilter);
 };


### PR DESCRIPTION
There are two problems when downloading file under Linux:
1. The default file name is not given. 
2. The saved file name does not have a suffix. For example, the file name specifies "test", the file filter is "(*.pptx)", and the last saved file name does not add ".pptx". In the Linux file manager, it will be recognized as a zip package, and double-clicking it will open the compression manager.
![qcefview_save_bug](https://github.com/CefView/QCefView/assets/1333855/ba669900-f095-4053-85ee-44d35d5502cd)
