### PR TITLE
feat: workaround to resolve the silent focus release issue

### DIFF
--- a/src/details/QCefViewPrivate.h
+++ b/src/details/QCefViewPrivate.h
@@ -82,6 +82,17 @@ public:
   /// </summary>
   struct OsrPrivateData
   {
+    /// <summary>
+    /// workaround for:
+    /// https://github.com/chromiumembedded/cef/issues/3870
+    /// after navigation CEF resets the browser focus status
+    /// without any callback notification (AKA, released the
+    /// focus silently), so we need to keep the CEF browser
+    /// focus status by ourself, and at every loadEnd callback
+    /// we need to sync the status to CEF browser.
+    /// </summary>
+    bool hasCefGotFocus_ = false;
+
     // IME parameters
     QRect qImeCursorRect_;
 

--- a/src/details/handler/CCefClientDelegate_LoadHandler.cpp
+++ b/src/details/handler/CCefClientDelegate_LoadHandler.cpp
@@ -30,6 +30,20 @@ CCefClientDelegate::loadEnd(CefRefPtr<CefBrowser>& browser, CefRefPtr<CefFrame>&
   if (!IsValidBrowser(browser))
     return;
 
+  // workaround for:
+  // https://github.com/chromiumembedded/cef/issues/3870
+  // after navigation CEF resets the browser focus status
+  // without any callback notification (AKA, released the
+  // focus silently), so we need to update the CEF browser
+  // focus status according to the one we have kept
+  if (true                                     //
+      && pCefViewPrivate_->isOSRModeEnabled_   //
+      && pCefViewPrivate_->osr.hasCefGotFocus_ //
+      && browser->GetHost()                    //
+  ) {
+    browser->GetHost()->SetFocus(true);
+  }
+
   emit pCefViewPrivate_->q_ptr->loadEnd(
     browser->GetIdentifier(), ValueConvertor::FrameIdC2Q(frame->GetIdentifier()), frame->IsMain(), httpStatusCode);
 }


### PR DESCRIPTION
- keep the CEF browser focus status
- sync the kept focus status back to CEF browser after navigation (CefLoadHandler::OnLoadEnd)

https://github.com/chromiumembedded/cef/issues/3870