### PR TITLE
feat: add cefWindowGotFocus signal to notify if CefWindow got focus

### DIFF
--- a/include/QCefView.h
+++ b/include/QCefView.h
@@ -425,6 +425,11 @@ signals:
   /// <param name="window">The native browser windows</param>
   void nativeBrowserCreated(QWindow* window);
 
+  /// <summary>
+  /// Gets called when the internal CefWindow gets focus.
+  /// </summary>
+  void cefWindowGotFocus();
+
 protected:
   /// <summary>
   /// Gets called before a new browser created (only for browser created by non-JavaScript)

--- a/src/details/QCefViewPrivate.cpp
+++ b/src/details/QCefViewPrivate.cpp
@@ -511,6 +511,8 @@ QCefViewPrivate::onCefWindowGotFocus()
   if (isOSRModeEnabled_) {
     osr.hasCefGotFocus_ = true;
   }
+
+  emit q->cefWindowGotFocus();
 }
 
 void


### PR DESCRIPTION
This MR adds a cefWindowGotFocus signal to QCefView and emits the signal if the CefWindow gets the focus.

This change allows to detect if the internal CefWindow got focus in both OSR mode on and off.
