### PR TITLE
fix: fix crash when close cef view window

### DIFF
--- a/include/QCefView.h
+++ b/include/QCefView.h
@@ -522,6 +522,13 @@ protected:
   /// <param name="event"></param>
   /// <returns></returns>
   bool event(QEvent* event) override;
+
+  /// <summary>
+  ///
+  /// </summary>
+  /// <param name="eventFilter"></param>
+  /// <returns></returns>
+  bool eventFilter(QObject* watched, QEvent* event) override;
 #pragma endregion
 };
 

--- a/src/QCefView.cpp
+++ b/src/QCefView.cpp
@@ -55,6 +55,9 @@ QCefView::QCefView(const QString& url,         //
       setAttribute(Qt::WA_PaintOnScreen);
     }
   }
+
+  if (window())
+    window()->installEventFilter(this);
 }
 
 QCefView::QCefView(QWidget* parent /*= 0*/, Qt::WindowFlags f /*= Qt::WindowFlags()*/)
@@ -65,12 +68,6 @@ QCefView::QCefView(QWidget* parent /*= 0*/, Qt::WindowFlags f /*= Qt::WindowFlag
 QCefView::~QCefView()
 {
   qDebug() << this << "is being destructed";
-
-  if (d_ptr) {
-    // destroy under layer cef browser
-    d_ptr->destroyCefBrowser();
-    d_ptr.reset();
-  }
 }
 
 void
@@ -472,4 +469,25 @@ QCefView::event(QEvent* event)
   }
 
   return QWidget::event(event);
+}
+
+bool
+QCefView::eventFilter(QObject* watched, QEvent* event)
+{
+  if (event->type() == QEvent::Close) {
+    if (d_ptr)
+      d_ptr->destroyCefBrowser();
+
+    setVisible(false);
+    auto p = parentWidget();
+    if (p) {
+      setParent(nullptr);
+    } else {
+      QCloseEvent* c = static_cast<QCloseEvent*>(event);
+      c->ignore();
+      return true;
+    }
+  }
+
+  return QWidget::eventFilter(watched, event);
 }

--- a/src/details/handler/CCefClientDelegate_LifeSpanHandler.cpp
+++ b/src/details/handler/CCefClientDelegate_LifeSpanHandler.cpp
@@ -204,4 +204,8 @@ CCefClientDelegate::requestClose(CefRefPtr<CefBrowser>& browser)
 void
 CCefClientDelegate::onBeforeClose(CefRefPtr<CefBrowser>& browser)
 {
+  if (!pCefViewPrivate_)
+    return;
+
+  pCefViewPrivate_->q_ptr->deleteLater();
 }


### PR DESCRIPTION
修复了在某些情况下QCefView关闭时会导致crash的bug。
相关的issue https://github.com/CefView/QCefView/issues/508
触发的原因：当前QCefView选择在析构的时候调用cef的api关闭浏览器，然后自己销毁。存在某些极端的case，QCefView析构了，但是cef的回调仍然触发，导致野指针crash。crash的简单复现办法，模拟cef某些回调长耗时，比如在 onPaint中增加sleep模拟耗时，在sleep期间关闭窗口，之后回调继续执行，触发crash。
<img width="3057" height="1472" alt="image" src="https://github.com/user-attachments/assets/2dd87a63-59f9-4e1f-a8bd-371df2356941" />

解决办法：
延迟QCefView的销毁时机。拦截QCefView的销毁动作，执行浏览器关闭动作，OnBeforeClose回调执行QCefView的deleteLater，保证cef的回调期间QCefView对象还未被销毁