### PR TITLE
尝试修复中文输入法候选字位置始终处于左上角，未跟随输入框光标焦点处

### DIFF
--- a/src/details/QCefViewPrivate.cpp
+++ b/src/details/QCefViewPrivate.cpp
@@ -1699,30 +1699,3 @@ QCefViewPrivate::zoomLevel()
 
   return 0;
 }
-
-void
-QCefViewPrivate::setImeComposition(const QList<QInputMethodEvent::Attribute>& attributes, const QString& composingText)
-{
-  CefCompositionUnderline underline;
-  underline.background_color = 0;
-  underline.range = { 0, static_cast<decltype(CefRange::to)>(composingText.length()) };
-
-  CefRange selectionRange;
-  for (auto& attr : attributes) {
-    switch (attr.type) {
-      case QInputMethodEvent::TextFormat:
-        break;
-      case QInputMethodEvent::Cursor:
-        selectionRange.Set(attr.start, attr.start);
-        break;
-      case QInputMethodEvent::Language:
-      case QInputMethodEvent::Ruby:
-      case QInputMethodEvent::Selection:
-        break;
-      default:
-        break;
-    }
-  }
-  pCefBrowser_->GetHost()->ImeSetComposition(
-    composingText.toStdString(), { underline }, CefRange(UINT32_MAX, UINT32_MAX), selectionRange);
-}


### PR DESCRIPTION
cef在离屏渲染模式下依赖输入法的预先上屏功能来定位光标的位置；而搜狗输入法没有提供该功能，中文输入法候选字位置始终处于左上角，未跟随输入框光标焦点处，目前采用把当前的输入模拟预先上屏发给cef；但该方法目前存在问题是输入框获得光标后的首字输入存在候选框位置更新不过来。