### PR TITLE
fix: fix compilation error on Windows 10 with SDK 10.0.19041

### DIFF
--- a/src/win/details/QCefContextPrivate_win.cpp
+++ b/src/win/details/QCefContextPrivate_win.cpp
@@ -1,6 +1,8 @@
 ﻿#include "../../details/QCefContextPrivate.h"
 
+#define NO_SHLWAPI_ISOS
 #include <Shlwapi.h>
+#undef NO_SHLWAPI_ISOS
 
 #include <QDebug>
 #include <QDir>


### PR DESCRIPTION
The top-level `CMakeLists.txt` defines the macro `OS_WINDOWS=1` on the Windows platform, which conflicts with a macro definition in the <Shlwapi.h> header file.