### PR TITLE
fix: fix destruct problem during initialization

### DIFF
--- a/src/details/QCefViewPrivate.cpp
+++ b/src/details/QCefViewPrivate.cpp
@@ -214,7 +214,7 @@ QCefViewPrivate::destroyCefBrowser()
 
   qDebug() << "destroy browser from native";
 
-  if (!isOSRModeEnabled_) {
+  if (!isOSRModeEnabled_ && ncw.qBrowserWidget_) {
     // remove from parent, prevent from being destroyed
     ncw.qBrowserWidget_->setParent(nullptr);
     ncw.qBrowserWidget_->deleteLater();


### PR DESCRIPTION
I developed a Qt GUI that acts as a plugin manager. In this application, when I rapidly load and unload a class implemented using qcefview, an exception is thrown inside the destroyCefBrowser() function.

By “rapidly,” I mean the following scenario: during the first initialization, the CEF library appears to asynchronously create a web context and its internal threads in the background. In other words, when a QCefView instance is created, this background initialization process has not yet fully completed. However, if I assume that the browser is already fully created and immediately call the destructor, ncw.qBrowserWidget ends up being nullptr.

I encountered this issue while testing edge cases in my system. If I activate the plugin and then deactivate it very quickly (for example, after about 0.2 seconds), the problem occurs. However, if I activate the plugin, wait for a certain amount of time (approximately 1.5 seconds), and then deactivate it, no issue occurs. Additionally, after the first successful initialization, even if I rapidly close and reopen the plugin, the problem no longer appears.

I should also mention that in my UI, it is not possible to remove or deactivate a plugin before it has been loaded. In other words, deactivation is only possible after the QCefView constructor has completed. Despite this, the issue still occurs, which suggests that although the constructor finishes, the internal CEF browser creation is still ongoing asynchronously.